### PR TITLE
Make library path handling OS independent

### DIFF
--- a/lib/serialize/ComponentConstructor.ts
+++ b/lib/serialize/ComponentConstructor.ts
@@ -1,3 +1,4 @@
+import * as Path from 'path';
 import { ContextParser, JsonLdContextNormalized } from 'jsonld-context-parser';
 import { ClassIndex, ClassLoaded, ClassReference } from '../parse/ClassIndex';
 import { ConstructorData } from '../parse/ConstructorLoader';
@@ -77,7 +78,7 @@ export class ComponentConstructor {
       '@type': 'Module',
       requireName: this.packageMetadata.name,
       import: Object.keys(definitions)
-        .map(pathAbsolute => `${pathAbsolute.slice(this.pathDestination.packageRootDirectory.length)}.${fileExtension}`)
+        .map(pathAbsolute => this.getPathRelative(`${pathAbsolute}.${fileExtension}`))
         .map(pathRelative => this.getImportPathIri(pathRelative))
         .map(iri => context.compactIri(iri)),
     };
@@ -92,9 +93,12 @@ export class ComponentConstructor {
       throw new Error(`Tried to reference a file outside the current package: ${sourcePath}`);
     }
 
-    return sourcePath
-      .slice(this.pathDestination.packageRootDirectory.length + 1)
-      .replace(`${this.pathDestination.originalPath}/`, '');
+    let strippedPath = sourcePath.slice(this.pathDestination.packageRootDirectory.length + 1);
+    if (Path.sep !== '/') {
+      strippedPath = strippedPath.split(Path.sep).join('/');
+    }
+
+    return strippedPath.replace(`${this.pathDestination.originalPath}/`, '');
   }
 
   /**

--- a/test/parse/ClassFinder.test.ts
+++ b/test/parse/ClassFinder.test.ts
@@ -1,3 +1,4 @@
+import * as Path from 'path';
 import { ClassFinder } from '../../lib/parse/ClassFinder';
 import { ClassLoader } from '../../lib/parse/ClassLoader';
 import { ResolutionContextMocked } from '../ResolutionContextMocked';
@@ -19,7 +20,7 @@ describe('ClassFinder', () => {
         .toEqual({
           named: {
             Class: {
-              fileName: 'lib/B',
+              fileName: Path.normalize('lib/B'),
               localName: 'B',
             },
           },
@@ -35,7 +36,7 @@ describe('ClassFinder', () => {
         .toEqual({
           named: {},
           unnamed: [
-            'lib/B',
+            Path.normalize('lib/B'),
           ],
         });
     });
@@ -72,20 +73,20 @@ export * from './lib/D';
         .toEqual({
           named: {
             Class1: {
-              fileName: 'lib/A',
+              fileName: Path.normalize('lib/A'),
               localName: 'A',
             },
             Class2: {
-              fileName: 'lib/B',
+              fileName: Path.normalize('lib/B'),
               localName: 'B',
             },
             Class3: {
-              fileName: 'lib/C',
+              fileName: Path.normalize('lib/C'),
               localName: 'C',
             },
           },
           unnamed: [
-            'lib/D',
+            Path.normalize('lib/D'),
           ],
         });
     });
@@ -180,7 +181,7 @@ export {A};
         .toEqual({
           named: {
             A: {
-              fileName: 'lib/A',
+              fileName: Path.normalize('lib/A'),
               localName: 'X',
             },
           },
@@ -217,13 +218,13 @@ export {A};
   describe('getPackageExports', () => {
     it('for a single named export', async() => {
       resolutionContext.contentsOverrides = {
-        'package-simple-named/index.d.ts': `export {A as B} from './lib/A';`,
-        'package-simple-named/lib/A.d.ts': 'export class A {}',
+        [Path.normalize('package-simple-named/index.d.ts')]: `export {A as B} from './lib/A';`,
+        [Path.normalize('package-simple-named/lib/A.d.ts')]: 'export class A {}',
       };
       expect(await parser.getPackageExports('package-simple-named'))
         .toEqual({
           B: {
-            fileName: 'package-simple-named/lib/A',
+            fileName: Path.normalize('package-simple-named/lib/A'),
             localName: 'A',
           },
         });
@@ -231,13 +232,13 @@ export {A};
 
     it('for a single unnamed export', async() => {
       resolutionContext.contentsOverrides = {
-        'package-simple-unnamed/index.d.ts': `export * from './lib/A';`,
-        'package-simple-unnamed/lib/A.d.ts': 'export class A {}',
+        [Path.normalize('package-simple-unnamed/index.d.ts')]: `export * from './lib/A';`,
+        [Path.normalize('package-simple-unnamed/lib/A.d.ts')]: 'export class A {}',
       };
       expect(await parser.getPackageExports('package-simple-unnamed'))
         .toEqual({
           A: {
-            fileName: 'package-simple-unnamed/lib/A',
+            fileName: Path.normalize('package-simple-unnamed/lib/A'),
             localName: 'A',
           },
         });
@@ -245,21 +246,21 @@ export {A};
 
     it('for a multiple exports', async() => {
       resolutionContext.contentsOverrides = {
-        'package-multiple/index.d.ts': `
+        [Path.normalize('package-multiple/index.d.ts')]: `
 export {A as B} from './lib/A';
 export * from './lib/C';
 `,
-        'package-multiple/lib/A.d.ts': 'export class A {}',
-        'package-multiple/lib/C.d.ts': 'export class C {}',
+        [Path.normalize('package-multiple/lib/A.d.ts')]: 'export class A {}',
+        [Path.normalize('package-multiple/lib/C.d.ts')]: 'export class C {}',
       };
       expect(await parser.getPackageExports('package-multiple'))
         .toEqual({
           B: {
-            fileName: 'package-multiple/lib/A',
+            fileName: Path.normalize('package-multiple/lib/A'),
             localName: 'A',
           },
           C: {
-            fileName: 'package-multiple/lib/C',
+            fileName: Path.normalize('package-multiple/lib/C'),
             localName: 'C',
           },
         });
@@ -267,22 +268,22 @@ export * from './lib/C';
 
     it('for nested exports', async() => {
       resolutionContext.contentsOverrides = {
-        'package-nested/index.d.ts': `export * from './lib/A';`,
-        'package-nested/lib/A.d.ts': `
+        [Path.normalize('package-nested/index.d.ts')]: `export * from './lib/A';`,
+        [Path.normalize('package-nested/lib/A.d.ts')]: `
 export * from './sub1/B'
 export * from './sub2/C'
 `,
-        'package-nested/lib/sub1/B.d.ts': 'export class B {}',
-        'package-nested/lib/sub2/C.d.ts': 'export class C {}',
+        [Path.normalize('package-nested/lib/sub1/B.d.ts')]: 'export class B {}',
+        [Path.normalize('package-nested/lib/sub2/C.d.ts')]: 'export class C {}',
       };
       expect(await parser.getPackageExports('package-nested'))
         .toEqual({
           B: {
-            fileName: 'package-nested/lib/sub1/B',
+            fileName: Path.normalize('package-nested/lib/sub1/B'),
             localName: 'B',
           },
           C: {
-            fileName: 'package-nested/lib/sub2/C',
+            fileName: Path.normalize('package-nested/lib/sub2/C'),
             localName: 'C',
           },
         });

--- a/test/parse/ClassLoader.test.ts
+++ b/test/parse/ClassLoader.test.ts
@@ -1,3 +1,4 @@
+import * as Path from 'path';
 import { AST, TSESTreeOptions, AST_NODE_TYPES } from '@typescript-eslint/typescript-estree';
 import { ClassLoader } from '../../lib/parse/ClassLoader';
 import { ResolutionContextMocked } from '../ResolutionContextMocked';
@@ -674,32 +675,32 @@ declare interface A{}
 
   describe('getClassElements', () => {
     it('for an empty file', () => {
-      expect(loader.getClassElements('dir/file', resolutionContext.parseTypescriptContents(``)))
+      expect(loader.getClassElements(Path.normalize('dir/file'), resolutionContext.parseTypescriptContents(``)))
         .toMatchObject({});
     });
 
     it('for a file with a const', () => {
-      expect(loader.getClassElements('dir/file', resolutionContext.parseTypescriptContents(`const a = "a"`)))
+      expect(loader.getClassElements(Path.normalize('dir/file'), resolutionContext.parseTypescriptContents(`const a = "a"`)))
         .toMatchObject({});
     });
 
     it('for a file with a const export', () => {
-      expect(loader.getClassElements('dir/file', resolutionContext.parseTypescriptContents(`export const foo = "a";`)))
+      expect(loader.getClassElements(Path.normalize('dir/file'), resolutionContext.parseTypescriptContents(`export const foo = "a";`)))
         .toMatchObject({});
     });
 
     it('for a file with a namespace import', () => {
-      expect(loader.getClassElements('dir/file', resolutionContext.parseTypescriptContents(`import polygons = Shapes.Polygons`)))
+      expect(loader.getClassElements(Path.normalize('dir/file'), resolutionContext.parseTypescriptContents(`import polygons = Shapes.Polygons`)))
         .toMatchObject({});
     });
 
     it('for a file with a default import', () => {
-      expect(loader.getClassElements('dir/file', resolutionContext.parseTypescriptContents(`import A from './lib/A'`)))
+      expect(loader.getClassElements(Path.normalize('dir/file'), resolutionContext.parseTypescriptContents(`import A from './lib/A'`)))
         .toMatchObject({});
     });
 
     it('for a single declare', () => {
-      expect(loader.getClassElements('dir/file', resolutionContext.parseTypescriptContents(`declare class A{}`)))
+      expect(loader.getClassElements(Path.normalize('dir/file'), resolutionContext.parseTypescriptContents(`declare class A{}`)))
         .toMatchObject({
           declaredClasses: {
             A: {
@@ -710,7 +711,7 @@ declare interface A{}
     });
 
     it('for a single declare abstract', () => {
-      expect(loader.getClassElements('dir/file', resolutionContext.parseTypescriptContents(`declare abstract class A{}`)))
+      expect(loader.getClassElements(Path.normalize('dir/file'), resolutionContext.parseTypescriptContents(`declare abstract class A{}`)))
         .toMatchObject({
           declaredClasses: {
             A: {
@@ -721,7 +722,7 @@ declare interface A{}
     });
 
     it('for a single declare interface', () => {
-      expect(loader.getClassElements('dir/file', resolutionContext.parseTypescriptContents(`declare interface A{}`)))
+      expect(loader.getClassElements(Path.normalize('dir/file'), resolutionContext.parseTypescriptContents(`declare interface A{}`)))
         .toMatchObject({
           declaredInterfaces: {
             A: {
@@ -732,19 +733,19 @@ declare interface A{}
     });
 
     it('for a single import', () => {
-      expect(loader.getClassElements('dir/file', resolutionContext.parseTypescriptContents(`import {A as B} from './lib/A'`)))
+      expect(loader.getClassElements(Path.normalize('dir/file'), resolutionContext.parseTypescriptContents(`import {A as B} from './lib/A'`)))
         .toMatchObject({
           importedElements: {
             B: {
               localName: 'A',
-              fileName: 'dir/lib/A',
+              fileName: Path.normalize('dir/lib/A'),
             },
           },
         });
     });
 
     it('for a single named export', () => {
-      expect(loader.getClassElements('dir/file', resolutionContext.parseTypescriptContents(`export class A{}`)))
+      expect(loader.getClassElements(Path.normalize('dir/file'), resolutionContext.parseTypescriptContents(`export class A{}`)))
         .toMatchObject({
           exportedClasses: {
             A: {
@@ -755,7 +756,7 @@ declare interface A{}
     });
 
     it('for a single named export abstract', () => {
-      expect(loader.getClassElements('dir/file', resolutionContext.parseTypescriptContents(`export abstract class A{}`)))
+      expect(loader.getClassElements(Path.normalize('dir/file'), resolutionContext.parseTypescriptContents(`export abstract class A{}`)))
         .toMatchObject({
           exportedClasses: {
             A: {
@@ -766,7 +767,7 @@ declare interface A{}
     });
 
     it('for a single named interface export', () => {
-      expect(loader.getClassElements('dir/file', resolutionContext.parseTypescriptContents(`export interface A{}`)))
+      expect(loader.getClassElements(Path.normalize('dir/file'), resolutionContext.parseTypescriptContents(`export interface A{}`)))
         .toMatchObject({
           exportedInterfaces: {
             A: {
@@ -777,14 +778,14 @@ declare interface A{}
     });
 
     it('for export all', () => {
-      expect(loader.getClassElements('dir/file', resolutionContext.parseTypescriptContents(`export * from './lib/A'`)))
+      expect(loader.getClassElements(Path.normalize('dir/file'), resolutionContext.parseTypescriptContents(`export * from './lib/A'`)))
         .toMatchObject({
-          exportedImportedAll: [ 'dir/lib/A' ],
+          exportedImportedAll: [ Path.normalize('dir/lib/A') ],
         });
     });
 
     it('for export all without source', () => {
-      expect(loader.getClassElements('dir/file', <AST<TSESTreeOptions>> {
+      expect(loader.getClassElements(Path.normalize('dir/file'), <AST<TSESTreeOptions>> {
         body: [
           {
             type: AST_NODE_TYPES.ExportAllDeclaration,
@@ -796,7 +797,7 @@ declare interface A{}
     });
 
     it('for export all without type', () => {
-      expect(loader.getClassElements('dir/file', <AST<TSESTreeOptions>> {
+      expect(loader.getClassElements(Path.normalize('dir/file'), <AST<TSESTreeOptions>> {
         body: [
           {
             type: AST_NODE_TYPES.ExportAllDeclaration,
@@ -808,7 +809,7 @@ declare interface A{}
     });
 
     it('for export all without value', () => {
-      expect(loader.getClassElements('dir/file', <AST<TSESTreeOptions>> {
+      expect(loader.getClassElements(Path.normalize('dir/file'), <AST<TSESTreeOptions>> {
         body: [
           {
             type: AST_NODE_TYPES.ExportAllDeclaration,
@@ -822,12 +823,12 @@ declare interface A{}
     });
 
     it('for a single named export without name should error', () => {
-      expect(() => loader.getClassElements('dir/file', resolutionContext.parseTypescriptContents(`export class{}`)))
-        .toThrow(new Error('Export parsing failure: missing exported class name in dir/file on line 1 column 7'));
+      expect(() => loader.getClassElements(Path.normalize('dir/file'), resolutionContext.parseTypescriptContents(`export class{}`)))
+        .toThrow(new Error(`Export parsing failure: missing exported class name in ${Path.normalize('dir/file')} on line 1 column 7`));
     });
 
     it('for a single export without target', () => {
-      expect(loader.getClassElements('dir/file', resolutionContext.parseTypescriptContents(`export { A as B }`)))
+      expect(loader.getClassElements(Path.normalize('dir/file'), resolutionContext.parseTypescriptContents(`export { A as B }`)))
         .toMatchObject({
           exportedUnknowns: {
             B: 'A',
@@ -836,39 +837,39 @@ declare interface A{}
     });
 
     it('for a single export from file', () => {
-      expect(loader.getClassElements('dir/file', resolutionContext.parseTypescriptContents(`export { A as B } from './lib/A'`)))
+      expect(loader.getClassElements(Path.normalize('dir/file'), resolutionContext.parseTypescriptContents(`export { A as B } from './lib/A'`)))
         .toMatchObject({
           exportedImportedElements: {
             B: {
               localName: 'A',
-              fileName: 'dir/lib/A',
+              fileName: Path.normalize('dir/lib/A'),
             },
           },
         });
     });
 
     it('for multiple exports from file', () => {
-      expect(loader.getClassElements('dir/file', resolutionContext.parseTypescriptContents(`export { A as B, C as D, X } from './lib/A'`)))
+      expect(loader.getClassElements(Path.normalize('dir/file'), resolutionContext.parseTypescriptContents(`export { A as B, C as D, X } from './lib/A'`)))
         .toMatchObject({
           exportedImportedElements: {
             B: {
               localName: 'A',
-              fileName: 'dir/lib/A',
+              fileName: Path.normalize('dir/lib/A'),
             },
             D: {
               localName: 'C',
-              fileName: 'dir/lib/A',
+              fileName: Path.normalize('dir/lib/A'),
             },
             X: {
               localName: 'X',
-              fileName: 'dir/lib/A',
+              fileName: Path.normalize('dir/lib/A'),
             },
           },
         });
     });
 
     it('for a mixed file', () => {
-      expect(loader.getClassElements('dir/file', resolutionContext.parseTypescriptContents(`
+      expect(loader.getClassElements(Path.normalize('dir/file'), resolutionContext.parseTypescriptContents(`
 declare class A{}
 declare class B{}
 import {C} from './lib/C'
@@ -886,11 +887,11 @@ import {D as X} from './lib/D'
           importedElements: {
             C: {
               localName: 'C',
-              fileName: 'dir/lib/C',
+              fileName: Path.normalize('dir/lib/C'),
             },
             X: {
               localName: 'D',
-              fileName: 'dir/lib/D',
+              fileName: Path.normalize('dir/lib/D'),
             },
           },
         });

--- a/test/parse/PackageMetadataLoader.test.ts
+++ b/test/parse/PackageMetadataLoader.test.ts
@@ -1,3 +1,4 @@
+import * as Path from 'path';
 import { PackageMetadataLoader } from '../../lib/parse/PackageMetadataLoader';
 import { ResolutionContextMocked } from '../ResolutionContextMocked';
 
@@ -13,12 +14,12 @@ describe('PackageMetadataLoader', () => {
     it('should error on a non-existing package.json', async() => {
       resolutionContext.contentsOverrides = {};
       await expect(loader.load('/')).rejects
-        .toThrow(new Error('Could not find mocked path for /package.json'));
+        .toThrow(new Error(`Could not find mocked path for ${Path.normalize('/package.json')}`));
     });
 
     it('should return with all required entries', async() => {
       resolutionContext.contentsOverrides = {
-        '/package.json': `{
+        [Path.normalize('/package.json')]: `{
   "name": "@solid/community-server",
   "version": "1.2.3",
   "lsd:module": "https://linkedsoftwaredependencies.org/bundles/npm/@solid/community-server",
@@ -33,7 +34,7 @@ describe('PackageMetadataLoader', () => {
 }`,
       };
       expect(await loader.load('/')).toEqual({
-        componentsPath: '/components/components.jsonld',
+        componentsPath: Path.normalize('/components/components.jsonld'),
         contexts: {
           'https://linkedsoftwaredependencies.org/bundles/npm/@solid/community-server/^1.0.0/components/context.jsonld':
             'components/context.jsonld',
@@ -50,15 +51,15 @@ describe('PackageMetadataLoader', () => {
 
     it('should error on invalid JSON', async() => {
       resolutionContext.contentsOverrides = {
-        '/package.json': `{`,
+        [Path.normalize('/package.json')]: `{`,
       };
       await expect(loader.load('/')).rejects
-        .toThrow(new Error('Invalid package: Syntax error in /package.json: Unexpected end of JSON input'));
+        .toThrow(new Error(`Invalid package: Syntax error in ${Path.normalize('/package.json')}: Unexpected end of JSON input`));
     });
 
     it('should error when lsd:module is missing', async() => {
       resolutionContext.contentsOverrides = {
-        '/package.json': `{
+        [Path.normalize('/package.json')]: `{
   "name": "@solid/community-server",
   "lsd:components": "components/components.jsonld",
   "lsd:contexts": {
@@ -67,12 +68,12 @@ describe('PackageMetadataLoader', () => {
 }`,
       };
       await expect(loader.load('/')).rejects
-        .toThrow(new Error('Invalid package: Missing \'lsd:module\' IRI in /package.json'));
+        .toThrow(new Error(`Invalid package: Missing 'lsd:module' IRI in ${Path.normalize('/package.json')}`));
     });
 
     it('should error when lsd:components is missing', async() => {
       resolutionContext.contentsOverrides = {
-        '/package.json': `{
+        [Path.normalize('/package.json')]: `{
   "name": "@solid/community-server",
   "lsd:module": "https://linkedsoftwaredependencies.org/bundles/npm/@solid/community-server",
   "lsd:contexts": {
@@ -81,24 +82,24 @@ describe('PackageMetadataLoader', () => {
 }`,
       };
       await expect(loader.load('/')).rejects
-        .toThrow(new Error('Invalid package: Missing \'lsd:components\' in /package.json'));
+        .toThrow(new Error(`Invalid package: Missing 'lsd:components' in ${Path.normalize('/package.json')}`));
     });
 
     it('should error when lsd:contexts is missing', async() => {
       resolutionContext.contentsOverrides = {
-        '/package.json': `{
+        [Path.normalize('/package.json')]: `{
   "name": "@solid/community-server",
   "lsd:module": "https://linkedsoftwaredependencies.org/bundles/npm/@solid/community-server",
   "lsd:components": "components/components.jsonld"
 }`,
       };
       await expect(loader.load('/')).rejects
-        .toThrow(new Error('Invalid package: Missing \'lsd:contexts\' in /package.json'));
+        .toThrow(new Error(`Invalid package: Missing 'lsd:contexts' in ${Path.normalize('/package.json')}`));
     });
 
     it('should error when lsd:importPaths is missing', async() => {
       resolutionContext.contentsOverrides = {
-        '/package.json': `{
+        [Path.normalize('/package.json')]: `{
   "name": "@solid/community-server",
   "lsd:module": "https://linkedsoftwaredependencies.org/bundles/npm/@solid/community-server",
   "lsd:components": "components/components.jsonld",
@@ -111,7 +112,7 @@ describe('PackageMetadataLoader', () => {
 }`,
       };
       await expect(loader.load('/')).rejects
-        .toThrow(new Error('Invalid package: Missing \'lsd:importPaths\' in /package.json'));
+        .toThrow(new Error(`Invalid package: Missing 'lsd:importPaths' in ${Path.normalize('/package.json')}`));
     });
   });
 });

--- a/test/serialize/ComponentSerialize.test.ts
+++ b/test/serialize/ComponentSerialize.test.ts
@@ -1,3 +1,4 @@
+import * as Path from 'path';
 import { ComponentSerializer } from '../../lib/serialize/ComponentSerializer';
 import { ResolutionContextMocked } from '../ResolutionContextMocked';
 
@@ -70,9 +71,9 @@ describe('ComponentSerializer', () => {
           'ex:my-package/file2.jsonld',
           'ex:my-package/file/a/b/c.jsonld',
         ],
-      })).toEqual('/components/components.jsonld');
+      })).toEqual(Path.normalize('/components/components.jsonld'));
       expect(resolutionContext.contentsOverrides).toEqual({
-        '/components/components.jsonld': `{
+        [Path.normalize('/components/components.jsonld')]: `{
   "@context": [
     "http://example.org/my-package/context.jsonld"
   ],
@@ -97,9 +98,9 @@ describe('ComponentSerializer', () => {
             a: 'b',
           },
         ],
-      })).toEqual('/components/context.jsonld');
+      })).toEqual(Path.normalize('/components/context.jsonld'));
       expect(resolutionContext.contentsOverrides).toEqual({
-        '/components/context.jsonld': `{
+        [Path.normalize('/components/context.jsonld')]: `{
   "@context": [
     {
       "a": "b"


### PR DESCRIPTION
The main change is the one in `ComponentConstructor`, but I also updated several of the unit tests to use the correct system paths based on the OS (many of them were failing on Windows because of that).