### PR TITLE
Fix Windows tests

### DIFF
--- a/test/parse/ClassFinder.test.ts
+++ b/test/parse/ClassFinder.test.ts
@@ -221,7 +221,7 @@ export {A};
         [Path.normalize('package-simple-named/index.d.ts')]: `export {A as B} from './lib/A';`,
         [Path.normalize('package-simple-named/lib/A.d.ts')]: 'export class A {}',
       };
-      expect(await parser.getPackageExports('package-simple-named/index'))
+      expect(await parser.getPackageExports(Path.normalize('package-simple-named/index')))
         .toEqual({
           B: {
             fileName: Path.normalize('package-simple-named/lib/A'),
@@ -235,7 +235,7 @@ export {A};
         [Path.normalize('package-simple-unnamed/index.d.ts')]: `export * from './lib/A';`,
         [Path.normalize('package-simple-unnamed/lib/A.d.ts')]: 'export class A {}',
       };
-      expect(await parser.getPackageExports('package-simple-unnamed/index'))
+      expect(await parser.getPackageExports(Path.normalize('package-simple-unnamed/index')))
         .toEqual({
           A: {
             fileName: Path.normalize('package-simple-unnamed/lib/A'),
@@ -253,7 +253,7 @@ export * from './lib/C';
         [Path.normalize('package-multiple/lib/A.d.ts')]: 'export class A {}',
         [Path.normalize('package-multiple/lib/C.d.ts')]: 'export class C {}',
       };
-      expect(await parser.getPackageExports('package-multiple/index'))
+      expect(await parser.getPackageExports(Path.normalize('package-multiple/index')))
         .toEqual({
           B: {
             fileName: Path.normalize('package-multiple/lib/A'),
@@ -276,7 +276,7 @@ export * from './sub2/C'
         [Path.normalize('package-nested/lib/sub1/B.d.ts')]: 'export class B {}',
         [Path.normalize('package-nested/lib/sub2/C.d.ts')]: 'export class C {}',
       };
-      expect(await parser.getPackageExports('package-nested/index'))
+      expect(await parser.getPackageExports(Path.normalize('package-nested/index')))
         .toEqual({
           B: {
             fileName: Path.normalize('package-nested/lib/sub1/B'),

--- a/test/serialize/ComponentConstructor.test.ts
+++ b/test/serialize/ComponentConstructor.test.ts
@@ -1370,7 +1370,7 @@ describe('ComponentConstructor', () => {
       const subParamData: ParameterData<ParameterRangeResolved> = (<any> parameterData).range.value[0];
       expect(() => ctor
         .constructFieldDefinitionNested(context, classReference, parameterData, parameters, subParamData, '', scope))
-        .toThrow(new Error(`Detected illegal indexed element inside a non-field in MyClass at /docs/package/src/a/b/file-param`));
+        .toThrow(new Error(`Detected illegal indexed element inside a non-field in MyClass at ${Path.normalize('/docs/package/src/a/b/file-param')}`));
     });
   });
 


### PR DESCRIPTION
Fixes all isues with windows when running the test (writing this before tests finished so fingers crossed).

I sort of regret initially having done this with Path.normalize everywhere in the tests as that is required for all tests now. It would have been better to have both os versions be able to support the paths of the other one, but that would require some internal code rework probably. It is also never going to actually be relevant so not really worth it.