### PR TITLE
fix: resolution of an index.d.ts inside a directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,10 +13,10 @@ output/
 **/test/**/*.js
 **/test/**/*.js.map
 **/test/**/*.d.ts
-!/test/data/**/*.d.ts
 **/bin/**/*.js
 **/bin/**/*.js.map
 **/bin/**/*.d.ts
 **/index.js
 **/index.js.map
 **/index.d.ts
+!/test/data/**/*.d.ts

--- a/lib/parse/ClassFinder.ts
+++ b/lib/parse/ClassFinder.ts
@@ -42,6 +42,7 @@ export class ClassFinder {
   Promise<{ named: ClassIndex<ClassReference>; unnamed: { packageName: string; fileName: string }[] }> {
     // Load the elements of the class
     const {
+      resolvedPath,
       exportedClasses,
       exportedInterfaces,
       exportedImportedElements,
@@ -63,8 +64,8 @@ export class ClassFinder {
         packageName,
         localName,
         qualifiedPath: undefined,
-        fileName,
-        fileNameReferenced: fileName,
+        fileName: resolvedPath,
+        fileNameReferenced: resolvedPath,
       };
     }
     for (const localName in exportedInterfaces) {
@@ -72,8 +73,8 @@ export class ClassFinder {
         packageName,
         localName,
         qualifiedPath: undefined,
-        fileName,
-        fileNameReferenced: fileName,
+        fileName: resolvedPath,
+        fileNameReferenced: resolvedPath,
       };
     }
 
@@ -84,7 +85,7 @@ export class ClassFinder {
         localName,
         qualifiedPath: undefined,
         fileName: importedFileName,
-        fileNameReferenced: fileName,
+        fileNameReferenced: resolvedPath,
       };
     }
 
@@ -98,8 +99,8 @@ export class ClassFinder {
             packageName,
             localName,
             qualifiedPath: undefined,
-            fileName,
-            fileNameReferenced: fileName,
+            fileName: resolvedPath,
+            fileNameReferenced: resolvedPath,
           };
           break;
         }
@@ -110,8 +111,8 @@ export class ClassFinder {
             packageName,
             localName,
             qualifiedPath: undefined,
-            fileName,
-            fileNameReferenced: fileName,
+            fileName: resolvedPath,
+            fileNameReferenced: resolvedPath,
           };
           break;
         }

--- a/lib/parse/ClassLoader.ts
+++ b/lib/parse/ClassLoader.ts
@@ -457,11 +457,17 @@ export class ClassLoader {
   /**
    * Load a class, and get all class elements from it.
    * @param packageName Package name we are importing from.
-   * @param fileName A file path.
+   * @param filePath A file path.
+   * @returns {Promise<ClassElements & { resolvedPath: string }>} Promise of the class elements along with
+   * the resolved file path that was used to load these class elements.
    */
-  public async loadClassElements(packageName: string, fileName: string): Promise<ClassElements> {
-    const ast = await this.resolutionContext.parseTypescriptFile(fileName);
-    return this.getClassElements(packageName, fileName, ast);
+  public async loadClassElements(packageName: string, filePath: string): Promise<
+  ClassElements & { resolvedPath: string }
+  > {
+    const resolvedPath = await this.resolutionContext.resolveTypesPath(filePath);
+    const ast = await this.resolutionContext.parseTypescriptFile(resolvedPath);
+    const classElements = this.getClassElements(packageName, resolvedPath, ast);
+    return { ...classElements, resolvedPath };
   }
 
   /**

--- a/lib/resolution/ResolutionContext.ts
+++ b/lib/resolution/ResolutionContext.ts
@@ -32,6 +32,26 @@ export class ResolutionContext {
   }
 
   /**
+   * Resolve the correct type declarations path for a specific path used
+   * in the exports.
+   *
+   * @param {string} filePath File path without .d.ts
+   * @returns {Promise<string>} Promise of the file path without .d.ts that is
+   *  either equal to the parameter or the index of the directory.
+   */
+  public resolveTypesPath(filePath: string): Promise<string> {
+    return new Promise(resolve => {
+      fs.access(`${filePath}.d.ts`, error => {
+        if (error) {
+          // No file found, treat as directory with an index
+          filePath = Path.normalize(`${filePath}/index`);
+        }
+        resolve(filePath);
+      });
+    });
+  }
+
+  /**
    * Write the content of a file.
    * If any of the underlying directories do not exist, they will be created.
    *

--- a/test/ResolutionContextMocked.ts
+++ b/test/ResolutionContextMocked.ts
@@ -1,4 +1,5 @@
 /* istanbul ignore file */
+import * as Path from 'path';
 import type { AST, TSESTreeOptions } from '@typescript-eslint/typescript-estree';
 import { ResolutionContext } from '../lib/resolution/ResolutionContext';
 
@@ -13,6 +14,15 @@ export class ResolutionContextMocked extends ResolutionContext {
     super();
     this.contentsOverrides = contentsOverrides;
     this.packageNameIndexOverrides = packageNameIndexOverrides;
+  }
+
+  public resolveTypesPath(filePath: string): Promise<string> {
+    return new Promise(resolve => {
+      if (!(`${filePath}.d.ts` in this.contentsOverrides)) {
+        return resolve(Path.normalize(`${filePath}/index`));
+      }
+      resolve(filePath);
+    });
   }
 
   public async getFileContent(filePath: string): Promise<string> {

--- a/test/data/directory/index.d.ts
+++ b/test/data/directory/index.d.ts
@@ -1,0 +1,1 @@
+export class MyClass {}

--- a/test/parse/ClassFinder.test.ts
+++ b/test/parse/ClassFinder.test.ts
@@ -359,6 +359,35 @@ export {A};
         });
     });
 
+    it('for a directory export', async() => {
+      resolutionContext.contentsOverrides = {
+        [Path.normalize('directory-export/index.d.ts')]: `
+          export * from './lib';
+        `,
+        [Path.normalize('directory-export/lib/index.d.ts')]: `
+        export * from './A';
+        export * from './C';
+        `,
+        [Path.normalize('directory-export/lib/A.d.ts')]: 'export class A {}',
+        [Path.normalize('directory-export/lib/C.d.ts')]: 'export class C {}',
+      };
+      expect(await parser.getPackageExports('package', Path.normalize('directory-export/index')))
+        .toEqual({
+          A: {
+            packageName: 'package',
+            fileName: Path.normalize('directory-export/lib/A'),
+            fileNameReferenced: Path.normalize('directory-export/lib/A'),
+            localName: 'A',
+          },
+          C: {
+            packageName: 'package',
+            fileName: Path.normalize('directory-export/lib/C'),
+            fileNameReferenced: Path.normalize('directory-export/lib/C'),
+            localName: 'C',
+          },
+        });
+    });
+
     it('for a multiple exports', async() => {
       resolutionContext.contentsOverrides = {
         [Path.normalize('package-multiple/index.d.ts')]: `

--- a/test/resolution/ResolutionContext.test.ts
+++ b/test/resolution/ResolutionContext.test.ts
@@ -168,4 +168,16 @@ describe('ResolutionContext', () => {
         .toEqual(Path.normalize('/root/abc.d.ts'));
     });
   });
+
+  describe('resolveTypesPath', () => {
+    it('Should resolve a types path of a directory', async() => {
+      expect(await resolutionContext.resolveTypesPath(`${__dirname}/../data/directory`))
+        .toEqual(Path.normalize(`${__dirname}/../data/directory/index`));
+    });
+
+    it('Should resolve a types path of a file', async() => {
+      expect(await resolutionContext.resolveTypesPath(`${__dirname}/../data/file`))
+        .toEqual(`${__dirname}/../data/file`);
+    });
+  });
 });


### PR DESCRIPTION
Closes #99 

This PR adds an additional check that verifies if the d.ts of a specific exported filePath exists. If not, it will attempt to treat the filePath as a directory.

More information in issue #99 

Workflow run: https://github.com/Maximvdw/Components-Generator.js/actions/runs/2227906346