### PR TITLE
Prevent invalid package.jsons from breaking the generation process

### DIFF
--- a/test/resolution/ExternalModulesLoader.test.ts
+++ b/test/resolution/ExternalModulesLoader.test.ts
@@ -92,6 +92,9 @@ describe('ExternalModulesLoader', () => {
     });
     req = {
       resolve(id: string, { paths }: any) {
+        if (id.includes('invalid')) {
+          throw new Error('invalid package');
+        }
         return paths[0] + id;
       },
     };
@@ -943,6 +946,15 @@ describe('ExternalModulesLoader', () => {
           '/path/to/package1',
           '/path/to/package2',
         ]);
+    });
+
+    it('should ignore invalid packages', () => {
+      expect(loader.buildNodeModulePathsSelective(req, [ '/path/to/' ], [ 'package1', 'invalid' ]))
+        .toEqual([
+          '/path/to/package1',
+        ]);
+      expect(logger.warn).toHaveBeenCalledTimes(1);
+      expect(logger.warn).toHaveBeenLastCalledWith(`Ignoring invalid package "invalid": invalid package`);
     });
   });
 


### PR DESCRIPTION
Closes https://github.com/LinkedSoftwareDependencies/Components-Generator.js/issues/95

The first commit solves the problem of the linked issue. But to make sure invalid packages can't break the process in general I also added the second commit. This should cover all `req.resolve` calls. Tried to do this with minimal changes as I'm not that familiar with everything that goes on in the codebase.