### PR TITLE
Ensure paths are treated correctly on Windows

### DIFF
--- a/lib/config/FileConfigLoader.ts
+++ b/lib/config/FileConfigLoader.ts
@@ -1,5 +1,5 @@
-import * as Path from 'path';
 import type { ResolutionContext } from '../resolution/ResolutionContext';
+import { joinFilePath } from '../util/PathUtil';
 import type { GeneratorConfig } from './GeneratorConfig';
 
 /**
@@ -20,7 +20,7 @@ export class FileConfigLoader {
    */
   public async getClosestConfigFile(cwd: string): Promise<Partial<GeneratorConfig> | undefined> {
     for (const directory of this.getConsideredDirectories(cwd)) {
-      const configPath = Path.join(directory, FileConfigLoader.DEFAULT_CONFIG_NAME);
+      const configPath = joinFilePath(directory, FileConfigLoader.DEFAULT_CONFIG_NAME);
       try {
         const textContents = await this.resolutionContext.getFileContent(configPath);
         return JSON.parse(textContents);

--- a/lib/config/GeneratorFactory.ts
+++ b/lib/config/GeneratorFactory.ts
@@ -1,7 +1,7 @@
-import * as Path from 'path';
 import type { LogLevel } from 'componentsjs';
 import { Generator } from '../generate/Generator';
 import type { ResolutionContext } from '../resolution/ResolutionContext';
+import { joinFilePath } from '../util/PathUtil';
 import { FileConfigLoader } from './FileConfigLoader';
 import type { GeneratorConfig } from './GeneratorConfig';
 
@@ -30,11 +30,11 @@ export class GeneratorFactory {
       resolutionContext: this.resolutionContext,
       pathDestinations: packageRootDirectories
         .filter(packageRootDirectory => !config.ignorePackagePaths
-          .some(ignorePackagePath => packageRootDirectory.startsWith(Path.join(cwd, ignorePackagePath))))
+          .some(ignorePackagePath => packageRootDirectory.startsWith(joinFilePath(cwd, ignorePackagePath))))
         .map(packageRootDirectory => ({
           packageRootDirectory,
-          originalPath: Path.posix.join(packageRootDirectory, config.source),
-          replacementPath: Path.posix.join(packageRootDirectory, config.destination),
+          originalPath: joinFilePath(packageRootDirectory, config.source),
+          replacementPath: joinFilePath(packageRootDirectory, config.destination),
         })),
       fileExtension: config.extension,
       logLevel: <LogLevel> config.logLevel,

--- a/lib/parse/ClassLoader.ts
+++ b/lib/parse/ClassLoader.ts
@@ -1,8 +1,8 @@
-import * as Path from 'path';
 import type { AST, TSESTreeOptions, TSESTree } from '@typescript-eslint/typescript-estree';
 import { AST_NODE_TYPES } from '@typescript-eslint/typescript-estree';
 import type { Logger } from 'winston';
 import type { ResolutionContext } from '../resolution/ResolutionContext';
+import { filePathDirName, joinFilePath } from '../util/PathUtil';
 import type {
   ClassLoaded,
   ClassReference,
@@ -486,7 +486,7 @@ export class ClassLoader {
     if (importPath.startsWith('.')) {
       return {
         packageName: currentPackageName,
-        fileName: Path.join(Path.dirname(currentFilePath), importPath),
+        fileName: joinFilePath(filePathDirName(currentFilePath), importPath),
         fileNameReferenced: currentFilePath,
       };
     }
@@ -529,7 +529,7 @@ export class ClassLoader {
       return;
     }
     const remoteFilePath = packagePath ?
-      Path.join(Path.dirname(packageRoot), packagePath) :
+      joinFilePath(filePathDirName(packageRoot), packagePath) :
       packageRoot.slice(0, packageRoot.indexOf('.', packageRoot.lastIndexOf('/')));
     return {
       packageName,

--- a/lib/parse/PackageMetadataLoader.ts
+++ b/lib/parse/PackageMetadataLoader.ts
@@ -1,6 +1,6 @@
-import * as Path from 'path';
 import semverMajor = require('semver/functions/major');
 import type { ResolutionContext } from '../resolution/ResolutionContext';
+import { joinFilePath } from '../util/PathUtil';
 
 /**
  * Load metadata from a package.
@@ -20,7 +20,7 @@ export class PackageMetadataLoader {
    */
   public async load(packageRootDirectory: string): Promise<PackageMetadata> {
     // Read package.json
-    const packageJsonPath = Path.join(packageRootDirectory, 'package.json');
+    const packageJsonPath = joinFilePath(packageRootDirectory, 'package.json');
     const packageJsonRaw = await this.resolutionContext.getFileContent(packageJsonPath);
     let packageJson: any;
     try {
@@ -54,7 +54,7 @@ export class PackageMetadataLoader {
     if (!('lsd:components' in packageJson)) {
       throw new Error(`Invalid package: Missing 'lsd:components' in ${packageJsonPath}`);
     }
-    const componentsPath = Path.join(packageRootDirectory, packageJson['lsd:components']);
+    const componentsPath = joinFilePath(packageRootDirectory, packageJson['lsd:components']);
     if (!('lsd:contexts' in packageJson)) {
       throw new Error(`Invalid package: Missing 'lsd:contexts' in ${packageJsonPath}`);
     }
@@ -66,7 +66,7 @@ export class PackageMetadataLoader {
     if (!('types' in packageJson) && !('typings' in packageJson)) {
       throw new Error(`Invalid package: Missing 'types' or 'typings' in ${packageJsonPath}`);
     }
-    let typesPath = Path.join(packageRootDirectory, packageJson.types || packageJson.typings);
+    let typesPath = joinFilePath(packageRootDirectory, packageJson.types || packageJson.typings);
     if (typesPath.endsWith('.d.ts')) {
       typesPath = typesPath.slice(0, -5);
     }

--- a/lib/resolution/ResolutionContext.ts
+++ b/lib/resolution/ResolutionContext.ts
@@ -1,8 +1,8 @@
 import * as fs from 'fs';
-import * as Path from 'path';
 import type { AST, TSESTreeOptions } from '@typescript-eslint/typescript-estree';
 import { parse } from '@typescript-eslint/typescript-estree';
 import * as LRUCache from 'lru-cache';
+import { filePathDirName, joinFilePath, normalizeFilePath } from '../util/PathUtil';
 
 /**
  * Context for loading files.
@@ -44,7 +44,7 @@ export class ResolutionContext {
       fs.access(`${filePath}.d.ts`, error => {
         if (error) {
           // No file found, treat as directory with an index
-          filePath = Path.normalize(`${filePath}/index`);
+          filePath = normalizeFilePath(`${filePath}/index`);
         }
         resolve(filePath);
       });
@@ -60,7 +60,7 @@ export class ResolutionContext {
    */
   public async writeFileContent(filePath: string, content: string): Promise<void> {
     await new Promise<void>((resolve, reject) => {
-      fs.mkdir(Path.dirname(filePath), { recursive: true }, error => {
+      fs.mkdir(filePathDirName(filePath), { recursive: true }, error => {
         if (error) {
           reject(error);
         } else {
@@ -155,6 +155,6 @@ export class ResolutionContext {
     if (!typesPath.endsWith('.d.ts')) {
       typesPath += '.d.ts';
     }
-    return Path.join(Path.dirname(packageJsonPath), typesPath);
+    return joinFilePath(filePathDirName(packageJsonPath), typesPath);
   }
 }

--- a/lib/serialize/ComponentConstructor.ts
+++ b/lib/serialize/ComponentConstructor.ts
@@ -1,4 +1,3 @@
-import * as Path from 'path';
 import type { ContextParser, JsonLdContextNormalized } from 'jsonld-context-parser';
 import semverMajor = require('semver/functions/major');
 import type {
@@ -135,11 +134,7 @@ export class ComponentConstructor {
       throw new Error(`Tried to reference a file outside the current package: ${sourcePath}`);
     }
 
-    let strippedPath = sourcePath.slice(pathDestination.packageRootDirectory.length + 1);
-    if (Path.sep !== '/') {
-      strippedPath = strippedPath.split(Path.sep).join('/');
-    }
-
+    const strippedPath = sourcePath.slice(pathDestination.packageRootDirectory.length + 1);
     return strippedPath.replace(`${pathDestination.originalPath}/`, '');
   }
 

--- a/lib/serialize/ComponentSerializer.ts
+++ b/lib/serialize/ComponentSerializer.ts
@@ -1,5 +1,5 @@
-import * as Path from 'path';
 import type { ResolutionContext } from '../resolution/ResolutionContext';
+import { joinFilePath } from '../util/PathUtil';
 import type { PathDestinationDefinition } from './ComponentConstructor';
 import type { ComponentDefinitions, ComponentDefinitionsIndex } from './ComponentDefinitions';
 import type { ContextRaw } from './ContextConstructor';
@@ -50,7 +50,7 @@ export class ComponentSerializer {
    * @return The absolute file path that was created.
    */
   public async serializeComponentsIndex(componentsIndex: ComponentDefinitionsIndex): Promise<string> {
-    const filePathBase = Path.join(
+    const filePathBase = joinFilePath(
       this.pathDestination.replacementPath,
       'components',
     );
@@ -63,7 +63,7 @@ export class ComponentSerializer {
    * @return The absolute file path that was created.
    */
   public async serializeContext(contextRaw: ContextRaw): Promise<string> {
-    const filePathBase = Path.join(
+    const filePathBase = joinFilePath(
       this.pathDestination.replacementPath,
       'context',
     );

--- a/lib/util/PathUtil.ts
+++ b/lib/util/PathUtil.ts
@@ -1,0 +1,46 @@
+import * as Path from 'path';
+
+/**
+ * Changes a potential Windows path into a POSIX path.
+ *
+ * @param path - Path to check (POSIX or Windows).
+ *
+ * @returns The potentially changed path (POSIX).
+ */
+function windowsToPosixPath(path: string): string {
+  return path.replace(/\\+/gu, '/');
+}
+
+/**
+ * Resolves relative segments in the path.
+ *
+ * @param path - Path to check (POSIX or Windows).
+ *
+ * @returns The potentially changed path (POSIX).
+ */
+export function normalizeFilePath(path: string): string {
+  return Path.posix.normalize(windowsToPosixPath(path));
+}
+
+/**
+ * Adds the paths to the base path.
+ *
+ * @param basePath - The base path (POSIX or Windows).
+ * @param paths - Subpaths to attach (POSIX).
+ *
+ * @returns The potentially changed path (POSIX).
+ */
+export function joinFilePath(basePath: string, ...paths: string[]): string {
+  return Path.posix.join(windowsToPosixPath(basePath), ...paths);
+}
+
+/**
+ * Returns the directory name of a path.
+ *
+ * @param path - Path to find directory of.
+ *
+ * @returns The directory path.
+ */
+export function filePathDirName(path: string): string {
+  return Path.posix.dirname(windowsToPosixPath(path));
+}

--- a/test/ResolutionContextMocked.ts
+++ b/test/ResolutionContextMocked.ts
@@ -1,7 +1,7 @@
 /* istanbul ignore file */
-import * as Path from 'path';
 import type { AST, TSESTreeOptions } from '@typescript-eslint/typescript-estree';
 import { ResolutionContext } from '../lib/resolution/ResolutionContext';
+import { normalizeFilePath } from '../lib/util/PathUtil';
 
 export class ResolutionContextMocked extends ResolutionContext {
   public contentsOverrides: Record<string, string | AST<TSESTreeOptions>>;
@@ -19,7 +19,7 @@ export class ResolutionContextMocked extends ResolutionContext {
   public resolveTypesPath(filePath: string): Promise<string> {
     return new Promise(resolve => {
       if (!(`${filePath}.d.ts` in this.contentsOverrides)) {
-        return resolve(Path.normalize(`${filePath}/index`));
+        return resolve(normalizeFilePath(`${filePath}/index`));
       }
       resolve(filePath);
     });

--- a/test/config/FileConfigLoader.test.ts
+++ b/test/config/FileConfigLoader.test.ts
@@ -1,5 +1,5 @@
-import * as Path from 'path';
 import { FileConfigLoader } from '../../lib/config/FileConfigLoader';
+import { normalizeFilePath } from '../../lib/util/PathUtil';
 import { ResolutionContextMocked } from '../ResolutionContextMocked';
 
 describe('FileConfigLoader', () => {
@@ -13,23 +13,25 @@ describe('FileConfigLoader', () => {
 
   describe('getClosestConfigFile', () => {
     it('should be undefined when no config file exists', async() => {
-      expect(await loader.getClosestConfigFile(Path.normalize('/a/b/c'))).toBeUndefined();
+      expect(await loader.getClosestConfigFile(normalizeFilePath('/a/b/c'))).toBeUndefined();
     });
 
     it('should be defined when a config file exists', async() => {
-      resolutionContext.contentsOverrides[Path.normalize('/a/b/c/.componentsjs-generator-config.json')] = `{ "a": true }`;
-      expect(await loader.getClosestConfigFile(Path.normalize('/a/b/c/'))).toEqual({ a: true });
+      resolutionContext.contentsOverrides[normalizeFilePath('/a/b/c/.componentsjs-generator-config.json')] = `{ "a": true }`;
+      expect(await loader.getClosestConfigFile(normalizeFilePath('/a/b/c/'))).toEqual({ a: true });
     });
 
     it('should be defined when a config file exists in parent directory', async() => {
-      resolutionContext.contentsOverrides[Path.normalize('/a/b/.componentsjs-generator-config.json')] = '{ "a": true }';
-      expect(await loader.getClosestConfigFile(Path.normalize('/a/b/c/'))).toEqual({ a: true });
+      resolutionContext
+        .contentsOverrides[normalizeFilePath('/a/b/.componentsjs-generator-config.json')] = '{ "a": true }';
+      expect(await loader.getClosestConfigFile(normalizeFilePath('/a/b/c/'))).toEqual({ a: true });
     });
 
     it('should be defined when multiple config files exists directory chain', async() => {
-      resolutionContext.contentsOverrides[Path.normalize('/a/b/c/.componentsjs-generator-config.json')] = `{ "a": true }`;
-      resolutionContext.contentsOverrides[Path.normalize('/a/b/.componentsjs-generator-config.json')] = '{ "b": true }';
-      expect(await loader.getClosestConfigFile(Path.normalize('/a/b/c/'))).toEqual({ a: true });
+      resolutionContext.contentsOverrides[normalizeFilePath('/a/b/c/.componentsjs-generator-config.json')] = `{ "a": true }`;
+      resolutionContext
+        .contentsOverrides[normalizeFilePath('/a/b/.componentsjs-generator-config.json')] = '{ "b": true }';
+      expect(await loader.getClosestConfigFile(normalizeFilePath('/a/b/c/'))).toEqual({ a: true });
     });
   });
 

--- a/test/config/GeneratorFactory.test.ts
+++ b/test/config/GeneratorFactory.test.ts
@@ -1,6 +1,6 @@
-import * as Path from 'path';
 import { GeneratorFactory } from '../../lib/config/GeneratorFactory';
 import { Generator } from '../../lib/generate/Generator';
+import { normalizeFilePath } from '../../lib/util/PathUtil';
 import { ResolutionContextMocked } from '../ResolutionContextMocked';
 
 describe('GeneratorFactory', () => {
@@ -15,30 +15,30 @@ describe('GeneratorFactory', () => {
   describe('createGenerator', () => {
     it('should create a new generator without custom options', async() => {
       expect(await factory.createGenerator(
-        Path.normalize('/root'),
+        normalizeFilePath('/root'),
         {},
-        [ Path.normalize('/root') ],
+        [ normalizeFilePath('/root') ],
       )).toBeInstanceOf(Generator);
     });
 
     it('should create a new generator with custom options', async() => {
-      resolutionContext.contentsOverrides[Path.normalize('/root/.componentsjs-generator-config.json')] = `{ "source": "FILESRC/", "extension": "FILEEXT", "debugState": true }`;
-      resolutionContext.contentsOverrides[Path.normalize('/root/.componentsignore')] = '[ "a", "b" ]';
+      resolutionContext.contentsOverrides[normalizeFilePath('/root/.componentsjs-generator-config.json')] = `{ "source": "FILESRC/", "extension": "FILEEXT", "debugState": true }`;
+      resolutionContext.contentsOverrides[normalizeFilePath('/root/.componentsignore')] = '[ "a", "b" ]';
       expect(await factory.createGenerator('/root', {
         c: 'COMPONENTS/',
         e: 'EXT',
         r: 'PRE',
-        i: Path.normalize('/root/.componentsignore'),
-      }, [ Path.normalize('/root') ])).toBeInstanceOf(Generator);
+        i: normalizeFilePath('/root/.componentsignore'),
+      }, [ normalizeFilePath('/root') ])).toBeInstanceOf(Generator);
     });
 
     it('should create a new generator when ignoring certain packages', async() => {
-      resolutionContext.contentsOverrides[Path.normalize('/root/.componentsjs-generator-config.json')] = `{ "ignorePackagePaths": [ "ignored1/", "ignored2/" ] }`;
-      expect(await factory.createGenerator(Path.normalize('/root'), {
+      resolutionContext.contentsOverrides[normalizeFilePath('/root/.componentsjs-generator-config.json')] = `{ "ignorePackagePaths": [ "ignored1/", "ignored2/" ] }`;
+      expect(await factory.createGenerator(normalizeFilePath('/root'), {
         c: 'COMPONENTS/',
         e: 'EXT',
         r: 'PRE',
-      }, [ Path.normalize('/root'), Path.normalize('/ignored1'), Path.normalize('/ignored2') ]))
+      }, [ normalizeFilePath('/root'), normalizeFilePath('/ignored1'), normalizeFilePath('/ignored2') ]))
         .toBeInstanceOf(Generator);
     });
   });
@@ -59,8 +59,8 @@ describe('GeneratorFactory', () => {
     });
 
     it('should handle no cli args and config file', async() => {
-      resolutionContext.contentsOverrides[Path.normalize('/root/.componentsjs-generator-config.json')] = `{ "source": "FILESRC/", "extension": "FILEEXT", "debugState": true }`;
-      expect(await factory.getConfig(Path.normalize('/root'), {})).toEqual({
+      resolutionContext.contentsOverrides[normalizeFilePath('/root/.componentsjs-generator-config.json')] = `{ "source": "FILESRC/", "extension": "FILEEXT", "debugState": true }`;
+      expect(await factory.getConfig(normalizeFilePath('/root'), {})).toEqual({
         source: 'FILESRC/',
         destination: 'components',
         extension: 'FILEEXT',
@@ -93,8 +93,8 @@ describe('GeneratorFactory', () => {
     });
 
     it('should handle cli args and config file', async() => {
-      resolutionContext.contentsOverrides[Path.normalize('/root/.componentsjs-generator-config.json')] = `{ "source": "FILESRC/", "extension": "FILEEXT", "debugState": true }`;
-      expect(await factory.getConfig(Path.normalize('/root'), {
+      resolutionContext.contentsOverrides[normalizeFilePath('/root/.componentsjs-generator-config.json')] = `{ "source": "FILESRC/", "extension": "FILEEXT", "debugState": true }`;
+      expect(await factory.getConfig(normalizeFilePath('/root'), {
         c: 'COMPONENTS/',
         e: 'EXT',
         r: 'PRE',

--- a/test/generate/Generator.test.ts
+++ b/test/generate/Generator.test.ts
@@ -1,5 +1,5 @@
-import * as Path from 'path';
 import { Generator } from '../../lib/generate/Generator';
+import { normalizeFilePath } from '../../lib/util/PathUtil';
 import { ResolutionContextMocked } from '../ResolutionContextMocked';
 
 describe('Generator', () => {
@@ -33,31 +33,31 @@ describe('Generator', () => {
 
   describe('generateComponents', () => {
     it('should run for valid packages', async() => {
-      resolutionContext.contentsOverrides[Path.normalize('pckg1/package.json')] = `{
+      resolutionContext.contentsOverrides[normalizeFilePath('pckg1/package.json')] = `{
   "name": "@solid/community-server",
   "version": "1.2.3",
   "lsd:module": true,
   "types": "./index.d.ts"
 }`;
-      resolutionContext.contentsOverrides[Path.normalize('pckg1/index.d.ts')] = ``;
-      resolutionContext.contentsOverrides[Path.normalize('pckg2/package.json')] = `{
+      resolutionContext.contentsOverrides[normalizeFilePath('pckg1/index.d.ts')] = ``;
+      resolutionContext.contentsOverrides[normalizeFilePath('pckg2/package.json')] = `{
   "name": "@solid/community-server2",
   "version": "1.2.3",
   "lsd:module": true,
   "types": "./index.d.ts"
 }`;
-      resolutionContext.contentsOverrides[Path.normalize('pckg2/index.d.ts')] = ``;
+      resolutionContext.contentsOverrides[normalizeFilePath('pckg2/index.d.ts')] = ``;
       await generator.generateComponents();
     });
 
     it('should run for only a single valid package', async() => {
-      resolutionContext.contentsOverrides[Path.normalize('pckg1/package.json')] = `{
+      resolutionContext.contentsOverrides[normalizeFilePath('pckg1/package.json')] = `{
   "name": "@solid/community-server",
   "version": "1.2.3",
   "lsd:module": true,
   "types": "./index.d.ts"
 }`;
-      resolutionContext.contentsOverrides[Path.normalize('pckg1/index.d.ts')] = ``;
+      resolutionContext.contentsOverrides[normalizeFilePath('pckg1/index.d.ts')] = ``;
       await generator.generateComponents();
     });
   });

--- a/test/parse/BulkPackageMetadataLoader.test.ts
+++ b/test/parse/BulkPackageMetadataLoader.test.ts
@@ -1,7 +1,7 @@
-import * as Path from 'path';
 import { JsonLdContextNormalized } from 'jsonld-context-parser';
 import { BulkPackageMetadataLoader } from '../../lib/parse/BulkPackageMetadataLoader';
 import { PackageMetadataLoader } from '../../lib/parse/PackageMetadataLoader';
+import { normalizeFilePath } from '../../lib/util/PathUtil';
 import { ResolutionContextMocked } from '../ResolutionContextMocked';
 
 describe('BulkPackageMetadataLoader', () => {
@@ -40,12 +40,12 @@ describe('BulkPackageMetadataLoader', () => {
         packageMetadatas: {},
         pathMetadatas: {},
       });
-      expect(logger.warn).toHaveBeenCalledWith(`Skipped generating invalid package at "/": Could not find mocked path for ${Path.normalize('/package.json')}`);
+      expect(logger.warn).toHaveBeenCalledWith(`Skipped generating invalid package at "/": Could not find mocked path for ${normalizeFilePath('/package.json')}`);
     });
 
     it('should skip an invalid package that does not exist', async() => {
       resolutionContext.contentsOverrides = {
-        [Path.normalize('/package.json')]: `{
+        [normalizeFilePath('/package.json')]: `{
   "name": "@solid/community-server",
   "version": "1.2.3"
 }`,
@@ -61,12 +61,12 @@ describe('BulkPackageMetadataLoader', () => {
         packageMetadatas: {},
         pathMetadatas: {},
       });
-      expect(logger.warn).toHaveBeenCalledWith(`Skipped generating invalid package at "/": Invalid package: Missing 'lsd:module' IRI in ${Path.normalize('/package.json')}`);
+      expect(logger.warn).toHaveBeenCalledWith(`Skipped generating invalid package at "/": Invalid package: Missing 'lsd:module' IRI in ${normalizeFilePath('/package.json')}`);
     });
 
     it('should a single valid paths', async() => {
       resolutionContext.contentsOverrides = {
-        [Path.normalize('/packages/pckg1/package.json')]: `{
+        [normalizeFilePath('/packages/pckg1/package.json')]: `{
   "name": "pckg1",
   "version": "1.2.3",
   "lsd:module": true,
@@ -85,7 +85,7 @@ describe('BulkPackageMetadataLoader', () => {
           pckg1: {
             minimalContext: expect.any(JsonLdContextNormalized),
             packageMetadata: {
-              componentsPath: Path.normalize('/packages/pckg1/components/components.jsonld'),
+              componentsPath: normalizeFilePath('/packages/pckg1/components/components.jsonld'),
               contexts: {
                 'https://linkedsoftwaredependencies.org/bundles/npm/pckg1/^1.0.0/components/context.jsonld':
                   'components/context.jsonld',
@@ -97,7 +97,7 @@ describe('BulkPackageMetadataLoader', () => {
               moduleIri: 'https://linkedsoftwaredependencies.org/bundles/npm/pckg1',
               name: 'pckg1',
               prefix: undefined,
-              typesPath: Path.normalize('/packages/pckg1/index'),
+              typesPath: normalizeFilePath('/packages/pckg1/index'),
               version: '1.2.3',
             },
             pathDestination: {
@@ -109,7 +109,7 @@ describe('BulkPackageMetadataLoader', () => {
         },
         pathMetadatas: {
           '/packages/pckg1': {
-            componentsPath: Path.normalize('/packages/pckg1/components/components.jsonld'),
+            componentsPath: normalizeFilePath('/packages/pckg1/components/components.jsonld'),
             contexts: {
               'https://linkedsoftwaredependencies.org/bundles/npm/pckg1/^1.0.0/components/context.jsonld':
                 'components/context.jsonld',
@@ -121,7 +121,7 @@ describe('BulkPackageMetadataLoader', () => {
             moduleIri: 'https://linkedsoftwaredependencies.org/bundles/npm/pckg1',
             name: 'pckg1',
             prefix: undefined,
-            typesPath: Path.normalize('/packages/pckg1/index'),
+            typesPath: normalizeFilePath('/packages/pckg1/index'),
             version: '1.2.3',
           },
         },
@@ -131,19 +131,19 @@ describe('BulkPackageMetadataLoader', () => {
 
     it('should multiple valid paths', async() => {
       resolutionContext.contentsOverrides = {
-        [Path.normalize('/packages/pckg1/package.json')]: `{
+        [normalizeFilePath('/packages/pckg1/package.json')]: `{
   "name": "pckg1",
   "version": "1.2.3",
   "lsd:module": true,
   "types": "./index.d.ts"
 }`,
-        [Path.normalize('/packages/pckg2/package.json')]: `{
+        [normalizeFilePath('/packages/pckg2/package.json')]: `{
   "name": "pckg2",
   "version": "1.2.3",
   "lsd:module": true,
   "types": "./index.d.ts"
 }`,
-        [Path.normalize('/packages/pckg3/package.json')]: `{
+        [normalizeFilePath('/packages/pckg3/package.json')]: `{
   "name": "pckg3",
   "version": "1.2.3",
   "lsd:module": true,

--- a/test/parse/ClassFinder.test.ts
+++ b/test/parse/ClassFinder.test.ts
@@ -1,7 +1,7 @@
-import * as Path from 'path';
 import { ClassFinder } from '../../lib/parse/ClassFinder';
 import { ClassLoader } from '../../lib/parse/ClassLoader';
 import { CommentLoader } from '../../lib/parse/CommentLoader';
+import { normalizeFilePath } from '../../lib/util/PathUtil';
 import { ResolutionContextMocked } from '../ResolutionContextMocked';
 
 describe('ClassFinder', () => {
@@ -27,7 +27,7 @@ describe('ClassFinder', () => {
           named: {
             Class: {
               packageName: 'package',
-              fileName: Path.normalize('lib/B'),
+              fileName: normalizeFilePath('lib/B'),
               fileNameReferenced: 'file',
               localName: 'B',
             },
@@ -46,7 +46,7 @@ describe('ClassFinder', () => {
           unnamed: [
             {
               packageName: 'package',
-              fileName: Path.normalize('lib/B'),
+              fileName: normalizeFilePath('lib/B'),
               fileNameReferenced: 'file',
             },
           ],
@@ -127,19 +127,19 @@ export * from './lib/D';
           named: {
             Class1: {
               packageName: 'package',
-              fileName: Path.normalize('lib/A'),
+              fileName: normalizeFilePath('lib/A'),
               fileNameReferenced: 'file',
               localName: 'A',
             },
             Class2: {
               packageName: 'package',
-              fileName: Path.normalize('lib/B'),
+              fileName: normalizeFilePath('lib/B'),
               fileNameReferenced: 'file',
               localName: 'B',
             },
             Class3: {
               packageName: 'package',
-              fileName: Path.normalize('lib/C'),
+              fileName: normalizeFilePath('lib/C'),
               fileNameReferenced: 'file',
               localName: 'C',
             },
@@ -147,7 +147,7 @@ export * from './lib/D';
           unnamed: [
             {
               packageName: 'package',
-              fileName: Path.normalize('lib/D'),
+              fileName: normalizeFilePath('lib/D'),
               fileNameReferenced: 'file',
             },
           ],
@@ -291,7 +291,7 @@ export {A};
           named: {
             A: {
               packageName: 'package',
-              fileName: Path.normalize('lib/A'),
+              fileName: normalizeFilePath('lib/A'),
               fileNameReferenced: 'file',
               localName: 'X',
             },
@@ -329,15 +329,15 @@ export {A};
   describe('getPackageExports', () => {
     it('for a single named export', async() => {
       resolutionContext.contentsOverrides = {
-        [Path.normalize('package-simple-named/index.d.ts')]: `export {A as B} from './lib/A';`,
-        [Path.normalize('package-simple-named/lib/A.d.ts')]: 'export class A {}',
+        [normalizeFilePath('package-simple-named/index.d.ts')]: `export {A as B} from './lib/A';`,
+        [normalizeFilePath('package-simple-named/lib/A.d.ts')]: 'export class A {}',
       };
-      expect(await parser.getPackageExports('package', Path.normalize('package-simple-named/index')))
+      expect(await parser.getPackageExports('package', normalizeFilePath('package-simple-named/index')))
         .toEqual({
           B: {
             packageName: 'package',
-            fileName: Path.normalize('package-simple-named/lib/A'),
-            fileNameReferenced: Path.normalize('package-simple-named/index'),
+            fileName: normalizeFilePath('package-simple-named/lib/A'),
+            fileNameReferenced: normalizeFilePath('package-simple-named/index'),
             localName: 'A',
           },
         });
@@ -345,15 +345,15 @@ export {A};
 
     it('for a single unnamed export', async() => {
       resolutionContext.contentsOverrides = {
-        [Path.normalize('package-simple-unnamed/index.d.ts')]: `export * from './lib/A';`,
-        [Path.normalize('package-simple-unnamed/lib/A.d.ts')]: 'export class A {}',
+        [normalizeFilePath('package-simple-unnamed/index.d.ts')]: `export * from './lib/A';`,
+        [normalizeFilePath('package-simple-unnamed/lib/A.d.ts')]: 'export class A {}',
       };
-      expect(await parser.getPackageExports('package', Path.normalize('package-simple-unnamed/index')))
+      expect(await parser.getPackageExports('package', normalizeFilePath('package-simple-unnamed/index')))
         .toEqual({
           A: {
             packageName: 'package',
-            fileName: Path.normalize('package-simple-unnamed/lib/A'),
-            fileNameReferenced: Path.normalize('package-simple-unnamed/lib/A'),
+            fileName: normalizeFilePath('package-simple-unnamed/lib/A'),
+            fileNameReferenced: normalizeFilePath('package-simple-unnamed/lib/A'),
             localName: 'A',
           },
         });
@@ -361,28 +361,28 @@ export {A};
 
     it('for a directory export', async() => {
       resolutionContext.contentsOverrides = {
-        [Path.normalize('directory-export/index.d.ts')]: `
+        [normalizeFilePath('directory-export/index.d.ts')]: `
           export * from './lib';
         `,
-        [Path.normalize('directory-export/lib/index.d.ts')]: `
+        [normalizeFilePath('directory-export/lib/index.d.ts')]: `
         export * from './A';
         export * from './C';
         `,
-        [Path.normalize('directory-export/lib/A.d.ts')]: 'export class A {}',
-        [Path.normalize('directory-export/lib/C.d.ts')]: 'export class C {}',
+        [normalizeFilePath('directory-export/lib/A.d.ts')]: 'export class A {}',
+        [normalizeFilePath('directory-export/lib/C.d.ts')]: 'export class C {}',
       };
-      expect(await parser.getPackageExports('package', Path.normalize('directory-export/index')))
+      expect(await parser.getPackageExports('package', normalizeFilePath('directory-export/index')))
         .toEqual({
           A: {
             packageName: 'package',
-            fileName: Path.normalize('directory-export/lib/A'),
-            fileNameReferenced: Path.normalize('directory-export/lib/A'),
+            fileName: normalizeFilePath('directory-export/lib/A'),
+            fileNameReferenced: normalizeFilePath('directory-export/lib/A'),
             localName: 'A',
           },
           C: {
             packageName: 'package',
-            fileName: Path.normalize('directory-export/lib/C'),
-            fileNameReferenced: Path.normalize('directory-export/lib/C'),
+            fileName: normalizeFilePath('directory-export/lib/C'),
+            fileNameReferenced: normalizeFilePath('directory-export/lib/C'),
             localName: 'C',
           },
         });
@@ -390,25 +390,25 @@ export {A};
 
     it('for a multiple exports', async() => {
       resolutionContext.contentsOverrides = {
-        [Path.normalize('package-multiple/index.d.ts')]: `
+        [normalizeFilePath('package-multiple/index.d.ts')]: `
 export {A as B} from './lib/A';
 export * from './lib/C';
 `,
-        [Path.normalize('package-multiple/lib/A.d.ts')]: 'export class A {}',
-        [Path.normalize('package-multiple/lib/C.d.ts')]: 'export class C {}',
+        [normalizeFilePath('package-multiple/lib/A.d.ts')]: 'export class A {}',
+        [normalizeFilePath('package-multiple/lib/C.d.ts')]: 'export class C {}',
       };
-      expect(await parser.getPackageExports('package', Path.normalize('package-multiple/index')))
+      expect(await parser.getPackageExports('package', normalizeFilePath('package-multiple/index')))
         .toEqual({
           B: {
             packageName: 'package',
-            fileName: Path.normalize('package-multiple/lib/A'),
-            fileNameReferenced: Path.normalize('package-multiple/index'),
+            fileName: normalizeFilePath('package-multiple/lib/A'),
+            fileNameReferenced: normalizeFilePath('package-multiple/index'),
             localName: 'A',
           },
           C: {
             packageName: 'package',
-            fileName: Path.normalize('package-multiple/lib/C'),
-            fileNameReferenced: Path.normalize('package-multiple/lib/C'),
+            fileName: normalizeFilePath('package-multiple/lib/C'),
+            fileNameReferenced: normalizeFilePath('package-multiple/lib/C'),
             localName: 'C',
           },
         });
@@ -416,26 +416,26 @@ export * from './lib/C';
 
     it('for nested exports', async() => {
       resolutionContext.contentsOverrides = {
-        [Path.normalize('package-nested/index.d.ts')]: `export * from './lib/A';`,
-        [Path.normalize('package-nested/lib/A.d.ts')]: `
+        [normalizeFilePath('package-nested/index.d.ts')]: `export * from './lib/A';`,
+        [normalizeFilePath('package-nested/lib/A.d.ts')]: `
 export * from './sub1/B'
 export * from './sub2/C'
 `,
-        [Path.normalize('package-nested/lib/sub1/B.d.ts')]: 'export class B {}',
-        [Path.normalize('package-nested/lib/sub2/C.d.ts')]: 'export class C {}',
+        [normalizeFilePath('package-nested/lib/sub1/B.d.ts')]: 'export class B {}',
+        [normalizeFilePath('package-nested/lib/sub2/C.d.ts')]: 'export class C {}',
       };
-      expect(await parser.getPackageExports('package', Path.normalize('package-nested/index')))
+      expect(await parser.getPackageExports('package', normalizeFilePath('package-nested/index')))
         .toEqual({
           B: {
             packageName: 'package',
-            fileName: Path.normalize('package-nested/lib/sub1/B'),
-            fileNameReferenced: Path.normalize('package-nested/lib/sub1/B'),
+            fileName: normalizeFilePath('package-nested/lib/sub1/B'),
+            fileNameReferenced: normalizeFilePath('package-nested/lib/sub1/B'),
             localName: 'B',
           },
           C: {
             packageName: 'package',
-            fileName: Path.normalize('package-nested/lib/sub2/C'),
-            fileNameReferenced: Path.normalize('package-nested/lib/sub2/C'),
+            fileName: normalizeFilePath('package-nested/lib/sub2/C'),
+            fileNameReferenced: normalizeFilePath('package-nested/lib/sub2/C'),
             localName: 'C',
           },
         });

--- a/test/parse/ClassLoader.test.ts
+++ b/test/parse/ClassLoader.test.ts
@@ -1,8 +1,8 @@
-import * as Path from 'path';
 import type { AST, TSESTreeOptions } from '@typescript-eslint/typescript-estree';
 import { AST_NODE_TYPES } from '@typescript-eslint/typescript-estree';
 import { ClassLoader } from '../../lib/parse/ClassLoader';
 import { CommentLoader } from '../../lib/parse/CommentLoader';
+import { normalizeFilePath } from '../../lib/util/PathUtil';
 import { ResolutionContextMocked } from '../ResolutionContextMocked';
 
 describe('ClassLoader', () => {
@@ -2363,7 +2363,7 @@ export = NS`,
       expect(loader.importTargetToAbsolutePath('package', 'dir/lib/fileA', './subdir/fileB'))
         .toEqual({
           packageName: 'package',
-          fileName: Path.normalize('dir/lib/subdir/fileB'),
+          fileName: normalizeFilePath('dir/lib/subdir/fileB'),
           fileNameReferenced: 'dir/lib/fileA',
         });
     });
@@ -2387,21 +2387,22 @@ export = NS`,
     });
 
     it('for a file in a package', () => {
-      resolutionContext.packageNameIndexOverrides['other-package'] = Path.normalize('/some-dir/index.js');
+      resolutionContext.packageNameIndexOverrides['other-package'] = normalizeFilePath('/some-dir/index.js');
       expect(loader.importTargetToAbsolutePath('package', 'dir/lib/fileA', 'other-package/lib/bla'))
         .toEqual({
           packageName: 'other-package',
-          fileName: Path.normalize('/some-dir/lib/bla'),
+          fileName: normalizeFilePath('/some-dir/lib/bla'),
           fileNameReferenced: 'dir/lib/fileA',
         });
     });
 
     it('for a scoped package', () => {
-      resolutionContext.packageNameIndexOverrides['@rubensworks/other-package'] = Path.normalize('/some-dir/index.js');
+      resolutionContext
+        .packageNameIndexOverrides['@rubensworks/other-package'] = normalizeFilePath('/some-dir/index.js');
       expect(loader.importTargetToAbsolutePath('package', 'dir/lib/fileA', '@rubensworks/other-package'))
         .toEqual({
           packageName: '@rubensworks/other-package',
-          fileName: Path.normalize('/some-dir/index'),
+          fileName: normalizeFilePath('/some-dir/index'),
           fileNameReferenced: 'dir/lib/fileA',
         });
     });
@@ -2412,18 +2413,19 @@ export = NS`,
     });
 
     it('for a file in a scoped package', () => {
-      resolutionContext.packageNameIndexOverrides['@rubensworks/other-package'] = Path.normalize('/some-dir/index.js');
+      resolutionContext
+        .packageNameIndexOverrides['@rubensworks/other-package'] = normalizeFilePath('/some-dir/index.js');
       expect(loader.importTargetToAbsolutePath('package', 'dir/lib/fileA', '@rubensworks/other-package/lib/bla'))
         .toEqual({
           packageName: '@rubensworks/other-package',
-          fileName: Path.normalize('/some-dir/lib/bla'),
+          fileName: normalizeFilePath('/some-dir/lib/bla'),
           fileNameReferenced: 'dir/lib/fileA',
         });
     });
   });
 
   describe('getClassElements', () => {
-    const fileName = Path.normalize('dir/file');
+    const fileName = normalizeFilePath('dir/file');
 
     it('for an empty file', () => {
       expect(loader.getClassElements('package', fileName, resolutionContext.parseTypescriptContents(``)))
@@ -2489,7 +2491,7 @@ export = NS`,
           importedElements: {
             B: {
               localName: 'A',
-              fileName: Path.normalize('dir/lib/A'),
+              fileName: normalizeFilePath('dir/lib/A'),
             },
           },
         });
@@ -2499,7 +2501,7 @@ export = NS`,
       expect(loader.getClassElements('package', fileName, resolutionContext.parseTypescriptContents(`import * as A from './lib/A'`)))
         .toMatchObject({
           importedElementsAllNamed: {
-            A: { packageName: 'package', fileName: Path.normalize('dir/lib/A') },
+            A: { packageName: 'package', fileName: normalizeFilePath('dir/lib/A') },
           },
         });
     });
@@ -2572,7 +2574,7 @@ export = NS`,
       expect(loader.getClassElements('package', fileName, resolutionContext.parseTypescriptContents(`export * from './lib/A'`)))
         .toMatchObject({
           exportedImportedAll: [
-            { packageName: 'package', fileName: Path.normalize('dir/lib/A') },
+            { packageName: 'package', fileName: normalizeFilePath('dir/lib/A') },
           ],
         });
     });
@@ -2591,7 +2593,7 @@ export = NS`,
       expect(loader.getClassElements('package', fileName, resolutionContext.parseTypescriptContents(`export * as A from './lib/A'`)))
         .toMatchObject({
           exportedImportedAllNamed: {
-            A: { packageName: 'package', fileName: Path.normalize('dir/lib/A') },
+            A: { packageName: 'package', fileName: normalizeFilePath('dir/lib/A') },
           },
         });
     });
@@ -2654,7 +2656,7 @@ export = NS`,
           exportedImportedElements: {
             B: {
               localName: 'A',
-              fileName: Path.normalize('dir/lib/A'),
+              fileName: normalizeFilePath('dir/lib/A'),
             },
           },
         });
@@ -2687,15 +2689,15 @@ export = NS`,
           exportedImportedElements: {
             B: {
               localName: 'A',
-              fileName: Path.normalize('dir/lib/A'),
+              fileName: normalizeFilePath('dir/lib/A'),
             },
             D: {
               localName: 'C',
-              fileName: Path.normalize('dir/lib/A'),
+              fileName: normalizeFilePath('dir/lib/A'),
             },
             X: {
               localName: 'X',
-              fileName: Path.normalize('dir/lib/A'),
+              fileName: normalizeFilePath('dir/lib/A'),
             },
           },
         });
@@ -2786,11 +2788,11 @@ import {D as X} from './lib/D'
           importedElements: {
             C: {
               localName: 'C',
-              fileName: Path.normalize('dir/lib/C'),
+              fileName: normalizeFilePath('dir/lib/C'),
             },
             X: {
               localName: 'D',
-              fileName: Path.normalize('dir/lib/D'),
+              fileName: normalizeFilePath('dir/lib/D'),
             },
           },
         });

--- a/test/parse/MemberLoader.test.ts
+++ b/test/parse/MemberLoader.test.ts
@@ -1,5 +1,3 @@
-import * as Path from 'path';
-
 import { ClassFinder } from '../../lib/parse/ClassFinder';
 import type { ClassReferenceLoadedClassOrInterface } from '../../lib/parse/ClassIndex';
 import { ClassIndexer } from '../../lib/parse/ClassIndexer';
@@ -7,6 +5,7 @@ import { ClassLoader } from '../../lib/parse/ClassLoader';
 import { CommentLoader } from '../../lib/parse/CommentLoader';
 import { MemberLoader } from '../../lib/parse/MemberLoader';
 import { ParameterLoader } from '../../lib/parse/ParameterLoader';
+import { normalizeFilePath } from '../../lib/util/PathUtil';
 import { ResolutionContextMocked } from '../ResolutionContextMocked';
 
 describe('MemberLoader', () => {
@@ -111,7 +110,7 @@ describe('MemberLoader', () => {
   });
 
   describe('collectClassFields', () => {
-    const fileName = Path.normalize('dir/file');
+    const fileName = normalizeFilePath('dir/file');
 
     function getClassBody(contents: string): ClassReferenceLoadedClassOrInterface {
       const body = classLoader.getClassElements('package', fileName, resolutionContext.parseTypescriptContents(`declare class A{${contents}}`)).declaredClasses.A.body;

--- a/test/parse/PackageMetadataLoader.test.ts
+++ b/test/parse/PackageMetadataLoader.test.ts
@@ -1,5 +1,5 @@
-import * as Path from 'path';
 import { PackageMetadataLoader } from '../../lib/parse/PackageMetadataLoader';
+import { normalizeFilePath } from '../../lib/util/PathUtil';
 import { ResolutionContextMocked } from '../ResolutionContextMocked';
 
 describe('PackageMetadataLoader', () => {
@@ -14,12 +14,12 @@ describe('PackageMetadataLoader', () => {
     it('should error on a non-existing package.json', async() => {
       resolutionContext.contentsOverrides = {};
       await expect(loader.load('/')).rejects
-        .toThrow(new Error(`Could not find mocked path for ${Path.normalize('/package.json')}`));
+        .toThrow(new Error(`Could not find mocked path for ${normalizeFilePath('/package.json')}`));
     });
 
     it('should return with all required entries', async() => {
       resolutionContext.contentsOverrides = {
-        [Path.normalize('/package.json')]: `{
+        [normalizeFilePath('/package.json')]: `{
   "name": "@solid/community-server",
   "version": "1.2.3",
   "lsd:module": "https://linkedsoftwaredependencies.org/bundles/npm/@solid/community-server",
@@ -35,7 +35,7 @@ describe('PackageMetadataLoader', () => {
 }`,
       };
       expect(await loader.load('/')).toEqual({
-        componentsPath: Path.normalize('/components/components.jsonld'),
+        componentsPath: normalizeFilePath('/components/components.jsonld'),
         contexts: {
           'https://linkedsoftwaredependencies.org/bundles/npm/@solid/community-server/^1.0.0/components/context.jsonld':
             'components/context.jsonld',
@@ -47,13 +47,13 @@ describe('PackageMetadataLoader', () => {
         moduleIri: 'https://linkedsoftwaredependencies.org/bundles/npm/@solid/community-server',
         name: '@solid/community-server',
         version: '1.2.3',
-        typesPath: Path.normalize('/index'),
+        typesPath: normalizeFilePath('/index'),
       });
     });
 
     it('should return with all required entries, but using typings', async() => {
       resolutionContext.contentsOverrides = {
-        [Path.normalize('/package.json')]: `{
+        [normalizeFilePath('/package.json')]: `{
   "name": "@solid/community-server",
   "version": "1.2.3",
   "lsd:module": "https://linkedsoftwaredependencies.org/bundles/npm/@solid/community-server",
@@ -69,7 +69,7 @@ describe('PackageMetadataLoader', () => {
 }`,
       };
       expect(await loader.load('/')).toEqual({
-        componentsPath: Path.normalize('/components/components.jsonld'),
+        componentsPath: normalizeFilePath('/components/components.jsonld'),
         contexts: {
           'https://linkedsoftwaredependencies.org/bundles/npm/@solid/community-server/^1.0.0/components/context.jsonld':
             'components/context.jsonld',
@@ -81,13 +81,13 @@ describe('PackageMetadataLoader', () => {
         moduleIri: 'https://linkedsoftwaredependencies.org/bundles/npm/@solid/community-server',
         name: '@solid/community-server',
         version: '1.2.3',
-        typesPath: Path.normalize('/index'),
+        typesPath: normalizeFilePath('/index'),
       });
     });
 
     it('should return with all required entries, but using typings without extension', async() => {
       resolutionContext.contentsOverrides = {
-        [Path.normalize('/package.json')]: `{
+        [normalizeFilePath('/package.json')]: `{
   "name": "@solid/community-server",
   "version": "1.2.3",
   "lsd:module": "https://linkedsoftwaredependencies.org/bundles/npm/@solid/community-server",
@@ -103,7 +103,7 @@ describe('PackageMetadataLoader', () => {
 }`,
       };
       expect(await loader.load('/')).toEqual({
-        componentsPath: Path.normalize('/components/components.jsonld'),
+        componentsPath: normalizeFilePath('/components/components.jsonld'),
         contexts: {
           'https://linkedsoftwaredependencies.org/bundles/npm/@solid/community-server/^1.0.0/components/context.jsonld':
             'components/context.jsonld',
@@ -115,13 +115,13 @@ describe('PackageMetadataLoader', () => {
         moduleIri: 'https://linkedsoftwaredependencies.org/bundles/npm/@solid/community-server',
         name: '@solid/community-server',
         version: '1.2.3',
-        typesPath: Path.normalize('/index'),
+        typesPath: normalizeFilePath('/index'),
       });
     });
 
     it('should return with all required entries with lsd:module true', async() => {
       resolutionContext.contentsOverrides = {
-        [Path.normalize('/package.json')]: `{
+        [normalizeFilePath('/package.json')]: `{
   "name": "@solid/community-server",
   "version": "1.2.3",
   "lsd:module": true,
@@ -129,7 +129,7 @@ describe('PackageMetadataLoader', () => {
 }`,
       };
       expect(await loader.load('/')).toEqual({
-        componentsPath: Path.normalize('/components/components.jsonld'),
+        componentsPath: normalizeFilePath('/components/components.jsonld'),
         contexts: {
           'https://linkedsoftwaredependencies.org/bundles/npm/@solid/community-server/^1.0.0/components/context.jsonld':
             'components/context.jsonld',
@@ -142,13 +142,13 @@ describe('PackageMetadataLoader', () => {
         moduleIri: 'https://linkedsoftwaredependencies.org/bundles/npm/@solid/community-server',
         name: '@solid/community-server',
         version: '1.2.3',
-        typesPath: Path.normalize('/index'),
+        typesPath: normalizeFilePath('/index'),
       });
     });
 
     it('should return with all required entries with lsd:module true and lsd:basePath', async() => {
       resolutionContext.contentsOverrides = {
-        [Path.normalize('/package.json')]: `{
+        [normalizeFilePath('/package.json')]: `{
   "name": "@solid/community-server",
   "version": "1.2.3",
   "lsd:module": true,
@@ -157,7 +157,7 @@ describe('PackageMetadataLoader', () => {
 }`,
       };
       expect(await loader.load('/')).toEqual({
-        componentsPath: Path.normalize('/dist/components/components.jsonld'),
+        componentsPath: normalizeFilePath('/dist/components/components.jsonld'),
         contexts: {
           'https://linkedsoftwaredependencies.org/bundles/npm/@solid/community-server/^1.0.0/components/context.jsonld':
             'dist/components/context.jsonld',
@@ -170,21 +170,21 @@ describe('PackageMetadataLoader', () => {
         moduleIri: 'https://linkedsoftwaredependencies.org/bundles/npm/@solid/community-server',
         name: '@solid/community-server',
         version: '1.2.3',
-        typesPath: Path.normalize('/index'),
+        typesPath: normalizeFilePath('/index'),
       });
     });
 
     it('should error on invalid JSON', async() => {
       resolutionContext.contentsOverrides = {
-        [Path.normalize('/package.json')]: `{`,
+        [normalizeFilePath('/package.json')]: `{`,
       };
       await expect(loader.load('/')).rejects
-        .toThrow(new Error(`Invalid package: Syntax error in ${Path.normalize('/package.json')}: Unexpected end of JSON input`));
+        .toThrow(new Error(`Invalid package: Syntax error in ${normalizeFilePath('/package.json')}: Unexpected end of JSON input`));
     });
 
     it('should error when lsd:module is missing', async() => {
       resolutionContext.contentsOverrides = {
-        [Path.normalize('/package.json')]: `{
+        [normalizeFilePath('/package.json')]: `{
   "name": "@solid/community-server",
   "lsd:components": "components/components.jsonld",
   "lsd:contexts": {
@@ -193,12 +193,12 @@ describe('PackageMetadataLoader', () => {
 }`,
       };
       await expect(loader.load('/')).rejects
-        .toThrow(new Error(`Invalid package: Missing 'lsd:module' IRI in ${Path.normalize('/package.json')}`));
+        .toThrow(new Error(`Invalid package: Missing 'lsd:module' IRI in ${normalizeFilePath('/package.json')}`));
     });
 
     it('should error when lsd:components is missing', async() => {
       resolutionContext.contentsOverrides = {
-        [Path.normalize('/package.json')]: `{
+        [normalizeFilePath('/package.json')]: `{
   "name": "@solid/community-server",
   "lsd:module": "https://linkedsoftwaredependencies.org/bundles/npm/@solid/community-server",
   "lsd:contexts": {
@@ -207,24 +207,24 @@ describe('PackageMetadataLoader', () => {
 }`,
       };
       await expect(loader.load('/')).rejects
-        .toThrow(new Error(`Invalid package: Missing 'lsd:components' in ${Path.normalize('/package.json')}`));
+        .toThrow(new Error(`Invalid package: Missing 'lsd:components' in ${normalizeFilePath('/package.json')}`));
     });
 
     it('should error when lsd:contexts is missing', async() => {
       resolutionContext.contentsOverrides = {
-        [Path.normalize('/package.json')]: `{
+        [normalizeFilePath('/package.json')]: `{
   "name": "@solid/community-server",
   "lsd:module": "https://linkedsoftwaredependencies.org/bundles/npm/@solid/community-server",
   "lsd:components": "components/components.jsonld"
 }`,
       };
       await expect(loader.load('/')).rejects
-        .toThrow(new Error(`Invalid package: Missing 'lsd:contexts' in ${Path.normalize('/package.json')}`));
+        .toThrow(new Error(`Invalid package: Missing 'lsd:contexts' in ${normalizeFilePath('/package.json')}`));
     });
 
     it('should error when lsd:importPaths is missing', async() => {
       resolutionContext.contentsOverrides = {
-        [Path.normalize('/package.json')]: `{
+        [normalizeFilePath('/package.json')]: `{
   "name": "@solid/community-server",
   "lsd:module": "https://linkedsoftwaredependencies.org/bundles/npm/@solid/community-server",
   "lsd:components": "components/components.jsonld",
@@ -237,12 +237,12 @@ describe('PackageMetadataLoader', () => {
 }`,
       };
       await expect(loader.load('/')).rejects
-        .toThrow(new Error(`Invalid package: Missing 'lsd:importPaths' in ${Path.normalize('/package.json')}`));
+        .toThrow(new Error(`Invalid package: Missing 'lsd:importPaths' in ${normalizeFilePath('/package.json')}`));
     });
 
     it('should error when types and typings is missing', async() => {
       resolutionContext.contentsOverrides = {
-        [Path.normalize('/package.json')]: `{
+        [normalizeFilePath('/package.json')]: `{
   "name": "@solid/community-server",
   "lsd:module": "https://linkedsoftwaredependencies.org/bundles/npm/@solid/community-server",
   "lsd:components": "components/components.jsonld",
@@ -256,7 +256,7 @@ describe('PackageMetadataLoader', () => {
 }`,
       };
       await expect(loader.load('/')).rejects
-        .toThrow(new Error(`Invalid package: Missing 'types' or 'typings' in ${Path.normalize('/package.json')}`));
+        .toThrow(new Error(`Invalid package: Missing 'types' or 'typings' in ${normalizeFilePath('/package.json')}`));
     });
 
     describe('for a given prefix', () => {
@@ -266,7 +266,7 @@ describe('PackageMetadataLoader', () => {
 
       it('should return with all required entries', async() => {
         resolutionContext.contentsOverrides = {
-          [Path.normalize('/package.json')]: `{
+          [normalizeFilePath('/package.json')]: `{
   "name": "@solid/community-server",
   "version": "1.2.3",
   "lsd:module": "https://linkedsoftwaredependencies.org/bundles/npm/@solid/community-server",
@@ -282,7 +282,7 @@ describe('PackageMetadataLoader', () => {
 }`,
         };
         expect(await loader.load('/')).toEqual({
-          componentsPath: Path.normalize('/components/components.jsonld'),
+          componentsPath: normalizeFilePath('/components/components.jsonld'),
           contexts: {
             [`https://linkedsoftwaredependencies.org/bundles/npm/@solid/community-server/^1.0.0/components/context.jsonld`]:
               'components/context.jsonld',
@@ -294,7 +294,7 @@ describe('PackageMetadataLoader', () => {
           moduleIri: 'https://linkedsoftwaredependencies.org/bundles/npm/@solid/community-server',
           name: '@solid/community-server',
           version: '1.2.3',
-          typesPath: Path.normalize('/index'),
+          typesPath: normalizeFilePath('/index'),
           prefix: 'PRE',
         });
       });
@@ -313,7 +313,7 @@ describe('PackageMetadataLoader', () => {
 
       it('should return with all required entries', async() => {
         resolutionContext.contentsOverrides = {
-          [Path.normalize('/package.json')]: `{
+          [normalizeFilePath('/package.json')]: `{
   "name": "@solid/community-server",
   "version": "1.2.3",
   "lsd:module": "https://linkedsoftwaredependencies.org/bundles/npm/@solid/community-server",
@@ -329,7 +329,7 @@ describe('PackageMetadataLoader', () => {
 }`,
         };
         expect(await loader.load('/')).toEqual({
-          componentsPath: Path.normalize('/components/components.jsonld'),
+          componentsPath: normalizeFilePath('/components/components.jsonld'),
           contexts: {
             [`https://linkedsoftwaredependencies.org/bundles/npm/@solid/community-server/^1.0.0/components/context.jsonld`]:
               'components/context.jsonld',
@@ -341,7 +341,7 @@ describe('PackageMetadataLoader', () => {
           moduleIri: 'https://linkedsoftwaredependencies.org/bundles/npm/@solid/community-server',
           name: '@solid/community-server',
           version: '1.2.3',
-          typesPath: Path.normalize('/index'),
+          typesPath: normalizeFilePath('/index'),
           prefix: 'css',
         });
       });

--- a/test/resolution/ResolutionContext.test.ts
+++ b/test/resolution/ResolutionContext.test.ts
@@ -1,6 +1,6 @@
 import * as fs from 'fs';
-import * as Path from 'path';
 import { ResolutionContext } from '../../lib/resolution/ResolutionContext';
+import { joinFilePath, normalizeFilePath } from '../../lib/util/PathUtil';
 
 describe('ResolutionContext', () => {
   let resolutionContext: ResolutionContext;
@@ -111,23 +111,23 @@ describe('ResolutionContext', () => {
 
   describe('resolvePackageIndex', () => {
     it('Should resolve from the currentFilePath for a package without separate typings', async() => {
-      expect(resolutionContext.resolvePackageIndex('asynciterator', Path.join(__dirname, '../../')))
-        .toEqual(Path.join(__dirname, '../../node_modules/asynciterator/dist/asynciterator.d.ts'));
+      expect(resolutionContext.resolvePackageIndex('asynciterator', joinFilePath(__dirname, '../../')))
+        .toEqual(joinFilePath(__dirname, '../../node_modules/asynciterator/dist/asynciterator.d.ts'));
     });
 
     it('Should resolve from the currentFilePath for a package with separate typings', async() => {
-      expect(resolutionContext.resolvePackageIndex('lru-cache', Path.join(__dirname, '../../')))
-        .toEqual(Path.join(__dirname, '../../node_modules/@types/lru-cache/index.d.ts'));
+      expect(resolutionContext.resolvePackageIndex('lru-cache', joinFilePath(__dirname, '../../')))
+        .toEqual(joinFilePath(__dirname, '../../node_modules/@types/lru-cache/index.d.ts'));
     });
 
     it('Should resolve from the currentFilePath for a package without separate typings without extension', async() => {
-      expect(resolutionContext.resolvePackageIndex('@comunica/bus-rdf-parse', Path.join(__dirname, '../../')))
-        .toEqual(Path.join(__dirname, '../../node_modules/@comunica/bus-rdf-parse/lib/index.d.ts'));
+      expect(resolutionContext.resolvePackageIndex('@comunica/bus-rdf-parse', joinFilePath(__dirname, '../../')))
+        .toEqual(joinFilePath(__dirname, '../../node_modules/@comunica/bus-rdf-parse/lib/index.d.ts'));
     });
 
     it('Should resolve from the currentFilePath for a built-in package', async() => {
-      expect(resolutionContext.resolvePackageIndex('stream', Path.join(__dirname, '../../')))
-        .toEqual(Path.join(__dirname, '../../node_modules/@types/node/stream.d.ts'));
+      expect(resolutionContext.resolvePackageIndex('stream', joinFilePath(__dirname, '../../')))
+        .toEqual(joinFilePath(__dirname, '../../node_modules/@types/node/stream.d.ts'));
     });
   });
 
@@ -138,7 +138,7 @@ describe('ResolutionContext', () => {
       });
       req.resolve = () => '/root/a/';
       expect(resolutionContext.resolvePackageIndexInner(req, 'asynciterator', ''))
-        .toEqual(Path.normalize('/root/abc.d.ts'));
+        .toEqual(normalizeFilePath('/root/abc.d.ts'));
     });
 
     it('Should handle package.json with typings field', async() => {
@@ -147,7 +147,7 @@ describe('ResolutionContext', () => {
       });
       req.resolve = () => '/root/a/';
       expect(resolutionContext.resolvePackageIndexInner(req, 'asynciterator', ''))
-        .toEqual(Path.normalize('/root/abc.d.ts'));
+        .toEqual(normalizeFilePath('/root/abc.d.ts'));
     });
 
     it('Should handle package.json with implicit types field', async() => {
@@ -156,7 +156,7 @@ describe('ResolutionContext', () => {
       });
       req.resolve = () => '/root/a/';
       expect(resolutionContext.resolvePackageIndexInner(req, 'asynciterator', ''))
-        .toEqual(Path.normalize('/root/abc.d.ts'));
+        .toEqual(normalizeFilePath('/root/abc.d.ts'));
     });
 
     it('Should handle package.json with types field without extension', async() => {
@@ -165,14 +165,14 @@ describe('ResolutionContext', () => {
       });
       req.resolve = () => '/root/a/';
       expect(resolutionContext.resolvePackageIndexInner(req, 'asynciterator', ''))
-        .toEqual(Path.normalize('/root/abc.d.ts'));
+        .toEqual(normalizeFilePath('/root/abc.d.ts'));
     });
   });
 
   describe('resolveTypesPath', () => {
     it('Should resolve a types path of a directory', async() => {
       expect(await resolutionContext.resolveTypesPath(`${__dirname}/../data/directory`))
-        .toEqual(Path.normalize(`${__dirname}/../data/directory/index`));
+        .toEqual(normalizeFilePath(`${__dirname}/../data/directory/index`));
     });
 
     it('Should resolve a types path of a file', async() => {

--- a/test/serialize/ComponentConstructor.test.ts
+++ b/test/serialize/ComponentConstructor.test.ts
@@ -1,4 +1,3 @@
-import * as Path from 'path';
 import { PrefetchedDocumentLoader } from 'componentsjs/lib/rdf/PrefetchedDocumentLoader';
 import type { JsonLdContextNormalized } from 'jsonld-context-parser';
 import { ContextParser } from 'jsonld-context-parser';
@@ -19,6 +18,7 @@ import type {
 } from '../../lib/serialize/ComponentConstructor';
 import { ComponentConstructor } from '../../lib/serialize/ComponentConstructor';
 import type { ParameterDefinition } from '../../lib/serialize/ComponentDefinitions';
+import { normalizeFilePath } from '../../lib/util/PathUtil';
 import { ContextConstructorMocked } from '../ContextConstructorMocked';
 
 describe('ComponentConstructor', () => {
@@ -35,7 +35,7 @@ describe('ComponentConstructor', () => {
       type: 'class',
       packageName: 'my-package',
       localName: 'MyClass',
-      fileName: Path.normalize('/docs/package/src/a/b/file-param'),
+      fileName: normalizeFilePath('/docs/package/src/a/b/file-param'),
       generics: {},
     };
 
@@ -73,7 +73,7 @@ describe('ComponentConstructor', () => {
     };
     const contextConstructor = new ContextConstructorMocked({ packageMetadata });
     pathDestination = {
-      packageRootDirectory: Path.normalize('/docs/package'),
+      packageRootDirectory: normalizeFilePath('/docs/package'),
       originalPath: 'src',
       replacementPath: 'components',
     };
@@ -113,14 +113,14 @@ describe('ComponentConstructor', () => {
           type: 'class',
           packageName: 'my-package',
           localName: 'MyClass1',
-          fileName: Path.normalize('/docs/package/src/b/file'),
+          fileName: normalizeFilePath('/docs/package/src/b/file'),
           generics: {},
         },
         MyClass2: {
           type: 'class',
           packageName: 'my-package',
           localName: 'MyClass2',
-          fileName: Path.normalize('/docs/package/src/b/file'),
+          fileName: normalizeFilePath('/docs/package/src/b/file'),
           generics: {},
         },
       };
@@ -181,7 +181,7 @@ describe('ComponentConstructor', () => {
         },
       };
       expect(await ctor.constructComponents()).toEqual({
-        [Path.normalize('/docs/package/components/b/file')]: {
+        [normalizeFilePath('/docs/package/components/b/file')]: {
           '@context': [
             'https://linkedsoftwaredependencies.org/bundles/npm/my-package/context.jsonld',
           ],
@@ -244,14 +244,14 @@ describe('ComponentConstructor', () => {
           type: 'class',
           packageName: 'my-package',
           localName: 'MyClass1',
-          fileName: Path.normalize('/docs/package/src/file1'),
+          fileName: normalizeFilePath('/docs/package/src/file1'),
           generics: {},
         },
         MyClass2: {
           type: 'class',
           packageName: 'my-package',
           localName: 'MyClass2',
-          fileName: Path.normalize('/docs/package/src/b/file2'),
+          fileName: normalizeFilePath('/docs/package/src/b/file2'),
           generics: {},
         },
       };
@@ -281,7 +281,7 @@ describe('ComponentConstructor', () => {
         },
       };
       expect(await ctor.constructComponents()).toEqual({
-        [Path.normalize('/docs/package/components/file1')]: {
+        [normalizeFilePath('/docs/package/components/file1')]: {
           '@context': [
             'https://linkedsoftwaredependencies.org/bundles/npm/my-package/context.jsonld',
           ],
@@ -296,7 +296,7 @@ describe('ComponentConstructor', () => {
             },
           ],
         },
-        [Path.normalize('/docs/package/components/b/file2')]: {
+        [normalizeFilePath('/docs/package/components/b/file2')]: {
           '@context': [
             'https://linkedsoftwaredependencies.org/bundles/npm/my-package/context.jsonld',
           ],
@@ -334,14 +334,14 @@ describe('ComponentConstructor', () => {
           type: 'class',
           packageName: 'my-package',
           localName: 'MyClass1',
-          fileName: Path.normalize('/docs/package/src/b/file'),
+          fileName: normalizeFilePath('/docs/package/src/b/file'),
           generics: {},
         },
         MyClass2: {
           type: 'class',
           packageName: 'my-package',
           localName: 'MyClass2',
-          fileName: Path.normalize('/docs/package/src/b/file'),
+          fileName: normalizeFilePath('/docs/package/src/b/file'),
           generics: {},
         },
       };
@@ -376,7 +376,7 @@ describe('ComponentConstructor', () => {
             classLoaded: <any> {
               packageName: 'other-package',
               localName: 'MyClass',
-              fileName: Path.normalize('/docs/package/src/b/file'),
+              fileName: normalizeFilePath('/docs/package/src/b/file'),
             },
             genericTypeInstantiations: [],
           },
@@ -386,7 +386,7 @@ describe('ComponentConstructor', () => {
             classLoaded: <any> {
               packageName: 'other-package',
               localName: 'MyClass',
-              fileName: Path.normalize('/docs/package/src/b/file'),
+              fileName: normalizeFilePath('/docs/package/src/b/file'),
             },
             genericTypeInstantiations: [],
           },
@@ -399,7 +399,7 @@ describe('ComponentConstructor', () => {
         },
       };
       expect(await ctor.constructComponents()).toEqual({
-        [Path.normalize('/docs/package/components/b/file')]: {
+        [normalizeFilePath('/docs/package/components/b/file')]: {
           '@context': [
             'https://linkedsoftwaredependencies.org/bundles/npm/my-package/context.jsonld',
             'http://example.org/context-other-package.jsonld',
@@ -447,8 +447,8 @@ describe('ComponentConstructor', () => {
           type: 'class',
           packageName: 'other-package',
           localName: 'MyClass',
-          fileName: Path.normalize('/docs/other-package/src/b/file'),
-          fileNameReferenced: Path.normalize('/docs/package/src/b/file'),
+          fileName: normalizeFilePath('/docs/other-package/src/b/file'),
+          fileNameReferenced: normalizeFilePath('/docs/package/src/b/file'),
           generics: {},
         },
       };
@@ -467,7 +467,7 @@ describe('ComponentConstructor', () => {
         },
       };
       expect(await ctor.constructComponents()).toEqual({
-        [Path.normalize('/docs/package/components/b/file')]: {
+        [normalizeFilePath('/docs/package/components/b/file')]: {
           '@context': [
             'https://linkedsoftwaredependencies.org/bundles/npm/my-package/context.jsonld',
             'http://example.org/context-other-package.jsonld',
@@ -492,19 +492,19 @@ describe('ComponentConstructor', () => {
           type: 'class',
           packageName: 'my-package',
           localName: 'MyClass1',
-          fileName: Path.normalize('/docs/package/src/b/file'),
+          fileName: normalizeFilePath('/docs/package/src/b/file'),
           generics: {},
         },
         MyClass2: {
           type: 'class',
           packageName: 'my-package',
           localName: 'MyClass2',
-          fileName: Path.normalize('/docs/package/src/b/file'),
+          fileName: normalizeFilePath('/docs/package/src/b/file'),
           generics: {},
         },
       };
       expect(await ctor.constructComponents()).toEqual({
-        [Path.normalize('/docs/package/components/b/file')]: {
+        [normalizeFilePath('/docs/package/components/b/file')]: {
           '@context': [
             'https://linkedsoftwaredependencies.org/bundles/npm/my-package/context.jsonld',
           ],
@@ -545,9 +545,9 @@ describe('ComponentConstructor', () => {
 
     it('should handle a non-empty index', async() => {
       expect(await ctor.constructComponentsIndex(<any> {
-        [Path.normalize('/docs/package/components/file1')]: true,
-        [Path.normalize('/docs/package/components/file2')]: true,
-        [Path.normalize('/docs/package/components/file/a/b/c')]: true,
+        [normalizeFilePath('/docs/package/components/file1')]: true,
+        [normalizeFilePath('/docs/package/components/file2')]: true,
+        [normalizeFilePath('/docs/package/components/file/a/b/c')]: true,
       })).toEqual({
         '@context': [
           'https://linkedsoftwaredependencies.org/bundles/npm/my-package/context.jsonld',
@@ -588,30 +588,16 @@ describe('ComponentConstructor', () => {
     });
 
     it('should handle a valid path', () => {
-      expect(ComponentConstructor.getPathRelative(pathDestination, Path.normalize('/docs/package/src/a/b/myFile')))
+      expect(ComponentConstructor.getPathRelative(pathDestination, normalizeFilePath('/docs/package/src/a/b/myFile')))
         .toEqual('a/b/myFile');
     });
 
-    it('should generate the correct path for POSIX path implementations.', () => {
-      const sep = Path.sep;
-      (<any> Path).sep = Path.posix.sep;
-      (<any> ctor).pathDestination.packageRootDirectory = Path.posix.normalize('/docs/package');
+    it('should generate the correct path.', () => {
+      (<any> ctor).pathDestination.packageRootDirectory = normalizeFilePath('/docs/package');
       expect(ComponentConstructor.getPathRelative(
         pathDestination,
-        Path.posix.normalize('/docs/package/src/a/b/myFile'),
+        normalizeFilePath('/docs/package/src/a/b/myFile'),
       )).toEqual('a/b/myFile');
-      (<any> Path).sep = sep;
-    });
-
-    it('should generate the correct path for win32 path implementations.', () => {
-      const sep = Path.sep;
-      (<any> Path).sep = Path.win32.sep;
-      (<any> ctor).pathDestination.packageRootDirectory = Path.win32.normalize('/docs/package');
-      expect(ComponentConstructor.getPathRelative(
-        pathDestination,
-        Path.win32.normalize('/docs/package/src/a/b/myFile'),
-      )).toEqual('a/b/myFile');
-      (<any> Path).sep = sep;
     });
   });
 
@@ -622,8 +608,8 @@ describe('ComponentConstructor', () => {
     });
 
     it('should handle a valid path', () => {
-      expect(ComponentConstructor.getPathDestination(pathDestination, Path.normalize('/docs/package/src/myFile')))
-        .toEqual(Path.normalize('/docs/package/components/myFile'));
+      expect(ComponentConstructor.getPathDestination(pathDestination, normalizeFilePath('/docs/package/src/myFile')))
+        .toEqual(normalizeFilePath('/docs/package/components/myFile'));
     });
   });
 
@@ -716,7 +702,7 @@ describe('ComponentConstructor', () => {
           classLoaded: <any> {
             packageName: 'my-package',
             localName: 'SuperClass',
-            fileName: Path.normalize('/docs/package/src/a/b/SuperFile'),
+            fileName: normalizeFilePath('/docs/package/src/a/b/SuperFile'),
           },
           genericTypeInstantiations: [],
         },
@@ -742,7 +728,7 @@ describe('ComponentConstructor', () => {
           classLoaded: <any> {
             packageName: 'my-package',
             localName: 'SuperInterface1',
-            fileName: Path.normalize('/docs/package/src/a/b/SuperFile1'),
+            fileName: normalizeFilePath('/docs/package/src/a/b/SuperFile1'),
           },
           genericTypeInstantiations: [],
         },
@@ -750,7 +736,7 @@ describe('ComponentConstructor', () => {
           classLoaded: <any> {
             packageName: 'my-package',
             localName: 'SuperInterface2',
-            fileName: Path.normalize('/docs/package/src/a/b/SuperFile2'),
+            fileName: normalizeFilePath('/docs/package/src/a/b/SuperFile2'),
           },
           genericTypeInstantiations: [],
         },
@@ -947,7 +933,7 @@ describe('ComponentConstructor', () => {
       expect(await ctor.classNameToId(context, externalContextsCallback, {
         packageName: 'my-package',
         localName: 'MyClass',
-        fileName: Path.normalize('/docs/package/src/a/b/MyOwnClass'),
+        fileName: normalizeFilePath('/docs/package/src/a/b/MyOwnClass'),
         fileNameReferenced: 'unused',
       })).toEqual('mp:components/a/b/MyOwnClass.jsonld#MyClass');
     });
@@ -964,7 +950,7 @@ describe('ComponentConstructor', () => {
       externalComponents.packagesBeingGenerated['other-package'] = {
         packageMetadata,
         pathDestination: {
-          packageRootDirectory: Path.normalize('/docs/other-package'),
+          packageRootDirectory: normalizeFilePath('/docs/other-package'),
           originalPath: 'src',
           replacementPath: 'components',
         },
@@ -978,7 +964,7 @@ describe('ComponentConstructor', () => {
       expect(await ctor.classNameToId(context, externalContextsCallback, {
         packageName: 'other-package',
         localName: 'MyClass',
-        fileName: Path.normalize('/docs/other-package/src/a/b/MyOwnClass'),
+        fileName: normalizeFilePath('/docs/other-package/src/a/b/MyOwnClass'),
         fileNameReferenced: 'unused',
       })).toEqual('op:components/a/b/MyOwnClass.jsonld#MyClass');
       expect(externalContextsCallback).toHaveBeenCalledWith('http://example.org/context-other-package.jsonld');
@@ -994,7 +980,7 @@ describe('ComponentConstructor', () => {
       expect(await ctor.classNameToId(context, externalContextsCallback, {
         packageName: 'other-package',
         localName: 'MyClass',
-        fileName: Path.normalize('/docs/other-package/src/a/b/MyOwnClass'),
+        fileName: normalizeFilePath('/docs/other-package/src/a/b/MyOwnClass'),
         fileNameReferenced: 'unused',
       })).toEqual('op:MyClass');
       expect(externalContextsCallback).toHaveBeenCalledWith('http://example.org/context-other-package.jsonld');
@@ -1010,7 +996,7 @@ describe('ComponentConstructor', () => {
       await expect(ctor.classNameToId(context, externalContextsCallback, {
         packageName: 'other-package',
         localName: 'MyClass',
-        fileName: Path.normalize('/docs/other-package/src/a/b/MyOwnClass'),
+        fileName: normalizeFilePath('/docs/other-package/src/a/b/MyOwnClass'),
         fileNameReferenced: 'unused',
       })).rejects.toThrow(`Tried to reference a class 'MyClass' from an external module 'other-package' that does not expose this component`);
     });
@@ -1025,7 +1011,7 @@ describe('ComponentConstructor', () => {
       expect(await ctor.classNameToId(context, externalContextsCallback, {
         packageName: 'other-package',
         localName: 'MyClass',
-        fileName: Path.normalize('/docs/other-package/src/a/b/MyOwnClass'),
+        fileName: normalizeFilePath('/docs/other-package/src/a/b/MyOwnClass'),
         fileNameReferenced: 'unused',
       })).toEqual('urn:npm:other-package:MyClass');
     });
@@ -1036,7 +1022,7 @@ describe('ComponentConstructor', () => {
       expect(ctor.fieldNameToId(context, {
         packageName: 'my-package',
         localName: 'MyClass',
-        fileName: Path.normalize('/docs/package/src/a/b/MyOwnClass'),
+        fileName: normalizeFilePath('/docs/package/src/a/b/MyOwnClass'),
         fileNameReferenced: 'unused',
       }, 'field', scope)).toEqual('mp:components/a/b/MyOwnClass.jsonld#MyClass_field');
     });
@@ -1047,7 +1033,7 @@ describe('ComponentConstructor', () => {
       expect(ctor.fieldNameToId(context, {
         packageName: 'my-package',
         localName: 'MyClass',
-        fileName: Path.normalize('/docs/package/src/a/b/MyOwnClass'),
+        fileName: normalizeFilePath('/docs/package/src/a/b/MyOwnClass'),
         fileNameReferenced: 'unused',
       }, 'field', scope)).toEqual('mp:components/a/b/MyOwnClass.jsonld#MyClass_a_b_field');
     });
@@ -1056,19 +1042,19 @@ describe('ComponentConstructor', () => {
       expect(ctor.fieldNameToId(context, {
         packageName: 'my-package',
         localName: 'MyClass',
-        fileName: Path.normalize('/docs/package/src/a/b/MyOwnClass'),
+        fileName: normalizeFilePath('/docs/package/src/a/b/MyOwnClass'),
         fileNameReferenced: 'unused',
       }, 'field', scope)).toEqual('mp:components/a/b/MyOwnClass.jsonld#MyClass_field');
       expect(ctor.fieldNameToId(context, {
         packageName: 'my-package',
         localName: 'MyClass',
-        fileName: Path.normalize('/docs/package/src/a/b/MyOwnClass'),
+        fileName: normalizeFilePath('/docs/package/src/a/b/MyOwnClass'),
         fileNameReferenced: 'unused',
       }, 'field', scope)).toEqual('mp:components/a/b/MyOwnClass.jsonld#MyClass_field_1');
       expect(ctor.fieldNameToId(context, {
         packageName: 'my-package',
         localName: 'MyClass',
-        fileName: Path.normalize('/docs/package/src/a/b/MyOwnClass'),
+        fileName: normalizeFilePath('/docs/package/src/a/b/MyOwnClass'),
         fileNameReferenced: 'unused',
       }, 'field', scope)).toEqual('mp:components/a/b/MyOwnClass.jsonld#MyClass_field_2');
     });
@@ -1085,7 +1071,7 @@ describe('ComponentConstructor', () => {
       externalComponents.packagesBeingGenerated['other-package'] = {
         packageMetadata,
         pathDestination: {
-          packageRootDirectory: Path.normalize('/docs/other-package'),
+          packageRootDirectory: normalizeFilePath('/docs/other-package'),
           originalPath: 'src',
           replacementPath: 'components',
         },
@@ -1099,7 +1085,7 @@ describe('ComponentConstructor', () => {
       expect(ctor.fieldNameToId(context, {
         packageName: 'other-package',
         localName: 'MyClass',
-        fileName: Path.normalize('/docs/other-package/src/a/b/MyOwnClass'),
+        fileName: normalizeFilePath('/docs/other-package/src/a/b/MyOwnClass'),
         fileNameReferenced: 'unused',
       }, 'field', scope)).toEqual('npmd:other-package/^3.0.0/components/a/b/MyOwnClass.jsonld#MyClass_field');
     });
@@ -1108,7 +1094,7 @@ describe('ComponentConstructor', () => {
       expect(() => ctor.fieldNameToId(context, {
         packageName: 'other-package',
         localName: 'MyClass',
-        fileName: Path.normalize('/docs/other-package/src/a/b/MyOwnClass'),
+        fileName: normalizeFilePath('/docs/other-package/src/a/b/MyOwnClass'),
         fileNameReferenced: 'unused',
       }, 'field', scope))
         .toThrowError(/Tried to reference a field field in ".*" outside the current package: .*/u);
@@ -1445,7 +1431,7 @@ describe('ComponentConstructor', () => {
             value: <ClassReferenceLoaded> {
               packageName: 'my-package',
               localName: 'ClassParam',
-              fileName: Path.normalize('/docs/package/src/a/b/file-param'),
+              fileName: normalizeFilePath('/docs/package/src/a/b/file-param'),
             },
             genericTypeParameterInstances: undefined,
           },
@@ -2427,7 +2413,7 @@ describe('ComponentConstructor', () => {
           '',
           scope,
         )).rejects
-        .toThrow(new Error(`Detected illegal indexed element inside a non-field in MyClass at ${Path.normalize('/docs/package/src/a/b/file-param')}`));
+        .toThrow(new Error(`Detected illegal indexed element inside a non-field in MyClass at ${normalizeFilePath('/docs/package/src/a/b/file-param')}`));
     });
   });
 
@@ -2465,7 +2451,7 @@ describe('ComponentConstructor', () => {
       const rangeValue: ClassReferenceLoaded = <any> {
         packageName: 'my-package',
         localName: 'ClassParam',
-        fileName: Path.normalize('/docs/package/src/a/b/file-param'),
+        fileName: normalizeFilePath('/docs/package/src/a/b/file-param'),
       };
       expect(await ctor.constructParameterRange(
         { type: 'class', value: rangeValue, genericTypeParameterInstances: undefined },
@@ -2479,7 +2465,7 @@ describe('ComponentConstructor', () => {
       const rangeValue: ClassReferenceLoaded = <any> {
         packageName: 'my-package',
         localName: 'ClassParam',
-        fileName: Path.normalize('/docs/package/src/a/b/file-param'),
+        fileName: normalizeFilePath('/docs/package/src/a/b/file-param'),
       };
       expect(await ctor.constructParameterRange(
         {
@@ -2551,7 +2537,7 @@ describe('ComponentConstructor', () => {
       const rangeValueClass: ClassReferenceLoaded = <any> {
         packageName: 'my-package',
         localName: 'ClassParam',
-        fileName: Path.normalize('/docs/package/src/a/b/file-param'),
+        fileName: normalizeFilePath('/docs/package/src/a/b/file-param'),
       };
       const children: ParameterRangeResolved[] = [
         { type: 'raw', value: 'boolean' },
@@ -2575,7 +2561,7 @@ describe('ComponentConstructor', () => {
       const rangeValueClass: ClassReferenceLoaded = <any> {
         packageName: 'my-package',
         localName: 'ClassParam',
-        fileName: Path.normalize('/docs/package/src/a/b/file-param'),
+        fileName: normalizeFilePath('/docs/package/src/a/b/file-param'),
       };
       const children: ParameterRangeResolved[] = [
         { type: 'raw', value: 'boolean' },
@@ -2599,7 +2585,7 @@ describe('ComponentConstructor', () => {
       const rangeValueClass: ClassReferenceLoaded = <any> {
         packageName: 'my-package',
         localName: 'ClassParam',
-        fileName: Path.normalize('/docs/package/src/a/b/file-param'),
+        fileName: normalizeFilePath('/docs/package/src/a/b/file-param'),
       };
       const elements: ParameterRangeResolved[] = [
         { type: 'raw', value: 'boolean' },
@@ -2623,7 +2609,7 @@ describe('ComponentConstructor', () => {
       const rangeValueClass: ClassReferenceLoaded = <any> {
         packageName: 'my-package',
         localName: 'ClassParam',
-        fileName: Path.normalize('/docs/package/src/a/b/file-param'),
+        fileName: normalizeFilePath('/docs/package/src/a/b/file-param'),
       };
       const elements: ParameterRangeResolved[] = [
         { type: 'rest', value: { type: 'raw', value: 'boolean' }},

--- a/test/serialize/ComponentSerialize.test.ts
+++ b/test/serialize/ComponentSerialize.test.ts
@@ -1,5 +1,5 @@
-import * as Path from 'path';
 import { ComponentSerializer } from '../../lib/serialize/ComponentSerializer';
+import { normalizeFilePath } from '../../lib/util/PathUtil';
 import { ResolutionContextMocked } from '../ResolutionContextMocked';
 
 describe('ComponentSerializer', () => {
@@ -71,9 +71,9 @@ describe('ComponentSerializer', () => {
           'ex:my-package/file2.jsonld',
           'ex:my-package/file/a/b/c.jsonld',
         ],
-      })).toEqual(Path.normalize('/components/components.jsonld'));
+      })).toEqual(normalizeFilePath('/components/components.jsonld'));
       expect(resolutionContext.contentsOverrides).toEqual({
-        [Path.normalize('/components/components.jsonld')]: `{
+        [normalizeFilePath('/components/components.jsonld')]: `{
   "@context": [
     "http://example.org/my-package/context.jsonld"
   ],
@@ -98,9 +98,9 @@ describe('ComponentSerializer', () => {
             a: 'b',
           },
         ],
-      })).toEqual(Path.normalize('/components/context.jsonld'));
+      })).toEqual(normalizeFilePath('/components/context.jsonld'));
       expect(resolutionContext.contentsOverrides).toEqual({
-        [Path.normalize('/components/context.jsonld')]: `{
+        [normalizeFilePath('/components/context.jsonld')]: `{
   "@context": [
     {
       "a": "b"


### PR DESCRIPTION
Closes https://github.com/LinkedSoftwareDependencies/Components-Generator.js/issues/114 and closes https://github.com/LinkedSoftwareDependencies/Components-Generator.js/issues/115

Did the same thing as we do with paths in CSS: putting all calls to the `path` import in a single file so other files don't have to worry about things like separators.