### PR TITLE
Fix for import extensions when using ESM

### DIFF
--- a/lib/parse/ClassLoader.ts
+++ b/lib/parse/ClassLoader.ts
@@ -484,9 +484,14 @@ export class ClassLoader {
   ): { packageName: string; fileName: string; fileNameReferenced: string } | undefined {
     // Handle import paths within the current package
     if (importPath.startsWith('.')) {
+      const fileName = joinFilePath(filePathDirName(currentFilePath), importPath);
+      const indexOfExtension = fileName.indexOf('.', fileName.lastIndexOf('/'));
+      const fileNameWithoutExtension = indexOfExtension === -1 ?
+        fileName :
+        fileName.slice(0, indexOfExtension);
       return {
         packageName: currentPackageName,
-        fileName: joinFilePath(filePathDirName(currentFilePath), importPath),
+        fileName: fileNameWithoutExtension,
         fileNameReferenced: currentFilePath,
       };
     }

--- a/test/parse/ClassLoader.test.ts
+++ b/test/parse/ClassLoader.test.ts
@@ -2368,6 +2368,15 @@ export = NS`,
         });
     });
 
+    it('for a local file imported with an extension', () => {
+      expect(loader.importTargetToAbsolutePath('package', 'dir/lib/fileA', './subdir/fileB.js'))
+        .toEqual({
+          packageName: 'package',
+          fileName: normalizeFilePath('dir/lib/subdir/fileB'),
+          fileNameReferenced: 'dir/lib/fileA',
+        });
+    });
+
     it('for a package', () => {
       resolutionContext.packageNameIndexOverrides['other-package'] = '/some-dir/index.js';
       expect(loader.importTargetToAbsolutePath('package', 'dir/lib/fileA', 'other-package'))


### PR DESCRIPTION
This PR fixes #7 which should be re-opened because running components-generator fails when using ESM with Typescript, which requires `.js` file extensions on all imports.