### PR TITLE
Update CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Load dependency cache
         uses: actions/cache@v4
         with:
-          path: .yarn
+          path: '**/node_modules'
           key: ${{ runner.os }}-modules-${{ hashFiles('yarn.lock') }}
       - name: Install dependencies
         run: yarn install --immutable
@@ -60,7 +60,7 @@ jobs:
       - name: Load dependency cache
         uses: actions/cache@v4
         with:
-          path: .yarn
+          path: '**/node_modules'
           key: ${{ runner.os }}-modules-${{ hashFiles('yarn.lock') }}
       - name: Install dependencies
         run: yarn install --immutable

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,65 +1,86 @@
 name: CI
 on: [push, pull_request]
-jobs:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  DEFAULT_NODE_VERSION: 22.x
+
+jobs:
   lint:
+    name: Lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/cache@v2
+      - name: Use Node.js ${{ env.DEFAULT_NODE_VERSION }}
+        uses: actions/setup-node@v4
         with:
-          path: '**/node_modules'
-          key: ${{ runner.os }}-lint-modules-${{ hashFiles('**/yarn.lock') }}
-      - uses: actions/setup-node@v2
-        with:
-          node-version: 20.x
-      - run: corepack enable
-      - run: yarn install
-      - run: yarn run lint
-
-  test:
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
-        node-version:
-          - 18.x
-          - 20.x
-          - 21.x
-    steps:
-      - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v2
-        with:
-          node-version: ${{ matrix.node-version }}
-      - name: Enable CorePack
+          node-version: ${{ env.DEFAULT_NODE_VERSION }}
+      - name: Enable corepack
         run: corepack enable
       - name: Ensure line endings are consistent
         run: git config --global core.autocrlf input
-      - name: Check out repository
-        uses: actions/checkout@v2
-      - uses: actions/cache@v2
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Load dependency cache
+        uses: actions/cache@v4
         with:
-          path: '**/node_modules'
-          key: ${{ runner.os }}-test-modules-${{ hashFiles('**/yarn.lock') }}
+          path: .yarn
+          key: ${{ runner.os }}-modules-${{ hashFiles('yarn.lock') }}
       - name: Install dependencies
-        run: yarn install
+        run: yarn install --immutable
+      - name: Run ESLint
+        run: yarn run lint
+  test:
+    name: Test
+    needs: lint
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os:
+          - ubuntu-latest
+          - windows-latest
+          - macos-latest
+        node-version:
+          - 18.x
+          - 20.x
+          - 22.x
+    steps:
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+      - name: Enable corepack
+        run: corepack enable
+      - name: Ensure line endings are consistent
+        run: git config --global core.autocrlf input
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Load dependency cache
+        uses: actions/cache@v4
+        with:
+          path: .yarn
+          key: ${{ runner.os }}-modules-${{ hashFiles('yarn.lock') }}
+      - name: Install dependencies
+        run: yarn install --immutable
       - name: Build project
         run: yarn run build
       - name: Run tests
         run: yarn run test
       - name: Submit coverage results
-        uses: coverallsapp/github-action@master
+        uses: coverallsapp/github-action@v2
         with:
           github-token: ${{ secrets.github_token }}
-          flag-name: run-${{ matrix.node-version }}
+          flag-name: ${{ matrix.node-version }}-${{ matrix.os }}
           parallel: true
-
   coveralls:
+    name: Coverage
     needs: test
     runs-on: ubuntu-latest
     steps:
       - name: Consolidate test coverage from different jobs
-        uses: coverallsapp/github-action@master
+        uses: coverallsapp/github-action@v2
         with:
           github-token: ${{ secrets.github_token }}
           parallel-finished: true


### PR DESCRIPTION
This is a small set of changes to bump the actions versions, and to add better names to some of the steps:
* Run tests on Node 22 instead of 21 (in addition to 18 and 20).
* Cache the `.yarn` folder because that is the main one needed for Yarn version 4.
* Wait for linting to finish before running unit tests. The CI is so short that this makes sense. If the CI is too slow, it is because Jest is running with too many workers, which will be fixed in another PR.
* Ensure the Coveralls coverage is supplied the correct key, to avoid false duplicates in the report.
* Cancel in-progress workflows when new commits are pushed to a branch.
* Use the `--immutable` flag to detect any lockfile inconsistencies in the CI.